### PR TITLE
Function was crashing , with ALARM:10 as overflowing array. replaced …

### DIFF
--- a/Grbl_Esp32/report.cpp
+++ b/Grbl_Esp32/report.cpp
@@ -123,12 +123,11 @@ void report_status_message(uint8_t status_code)
 // Prints alarm messages.
 void report_alarm_message(uint8_t alarm_code)
 {
-	char alarm[10];
-	
-	sprintf(alarm, "ALARM:%d\r\n", alarm_code);
+	char alarm[32];
+	snprintf(alarm, 32, "ALARM:%d\r\n", alarm_code);
 	grbl_send(alarm);
-	
-  delay_ms(500); // Force delay to ensure message clears serial write buffer.
+
+	delay_ms(500); // Force delay to ensure message clears serial write buffer.
 }
 
 // Prints feedback messages. This serves as a centralized method to provide additional


### PR DESCRIPTION
Function was crashing , with ALARM:10 as overflowing array. replaced with larger array  + use of snprintf to truncate rather than overflow in the future.

I've added Alarm 10 as motor error in my working copy , this caused the above fault.

First attempt at a pull request , won't be offended if you reject in favour of Luc's grbl_sendf(..) function :)