### PR TITLE
Allow for no probe pin

### DIFF
--- a/Grbl_Esp32/gcode.cpp
+++ b/Grbl_Esp32/gcode.cpp
@@ -163,7 +163,10 @@ uint8_t gc_execute_line(char *line, uint8_t client)
               mantissa = 0; // Set to zero to indicate valid non-integer G command.
             }                
             break;
-          case 0: case 1: case 2: case 3: case 38:
+          case 0: case 1: case 2: case 3:
+#ifdef PROBE_PIN //only allow G38 "Probe" commands if a probe pin is defined.
+	  case 38: 
+#endif			
             // Check for G0/1/2/3/38 being called with G10/28/30/92 on same block.
             // * G43.1 is also an axis command but is not explicitly defined this way.
             if (axis_command) { FAIL(STATUS_GCODE_AXIS_COMMAND_CONFLICT); } // [Axis word/command conflict]

--- a/Grbl_Esp32/probe.cpp
+++ b/Grbl_Esp32/probe.cpp
@@ -31,7 +31,7 @@ uint8_t probe_invert_mask;
 // Probe pin initialization routine.
 void probe_init()
 {
-  
+#ifdef PROBE_PIN
   #ifdef DISABLE_PROBE_PIN_PULL_UP
     pinMode(PROBE_PIN, INPUT);
   #else
@@ -40,6 +40,7 @@ void probe_init()
 
   
   probe_configure_invert_mask(false); // Initialize invert mask.
+#endif
 }
 
 
@@ -56,7 +57,11 @@ void probe_configure_invert_mask(uint8_t is_probe_away)
 // Returns the probe pin state. Triggered = true. Called by gcode parser and probe state monitor.
 uint8_t probe_get_state() 
 { 
+#ifdef PROBE_PIN
 	return((digitalRead(PROBE_PIN)) ^ probe_invert_mask); 
+#else
+	return false;
+#endif
 }
 
 


### PR DESCRIPTION
added ifdef to allow probe pin to not be defined. Will always indicate not triggered.