### PR TITLE
Changed status report number format for FS: and F: fields

### DIFF
--- a/Grbl_Esp32/report.cpp
+++ b/Grbl_Esp32/report.cpp
@@ -641,11 +641,11 @@ void report_realtime_status(uint8_t client)
   // Report realtime feed speed
   #ifdef REPORT_FIELD_CURRENT_FEED_SPEED
     #ifdef VARIABLE_SPINDLE      
-			sprintf(temp, "|FS:%4.3f,%4.3f", st_get_realtime_rate(), sys.spindle_speed);
+			sprintf(temp, "|FS:%.0f,%.0f", st_get_realtime_rate(), sys.spindle_speed);
 			strcat(status, temp);
     #else
       
-			sprintf(temp, "|F:%4.3f", st_get_realtime_rate());
+			sprintf(temp, "|F:%.0f", st_get_realtime_rate());
 			strcat(status, temp);
     #endif      
   #endif


### PR DESCRIPTION
 Changed FS and F field values from floats to integers.
This change was made to be compatible with LaserGRBL status report parsing (which will not tolerate FS: report with floats), and to be more closely aligned with GRBL real time status report specification documentation, which shows int values in this field rather than floats in the example.