### PR TITLE
Allow Ctrl inputs to be disabled

### DIFF
--- a/Grbl_Esp32/system.cpp
+++ b/Grbl_Esp32/system.cpp
@@ -1,6 +1,6 @@
 /*
   system.cpp - Header for system level commands and real-time processes
-  Part of Grbl
+  art of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 	
 	2018 -	Bart Dring This file was modified for use on the ESP32
@@ -24,16 +24,23 @@
 void system_ini() // Renamed from system_init() due to conflict with esp32 files
 {	
 	// setup control inputs
+#ifdef CONTROL_SAFETY_DOOR_PIN
 	pinMode(CONTROL_SAFETY_DOOR_PIN, INPUT);
-  pinMode(CONTROL_RESET_PIN, INPUT);
-  pinMode(CONTROL_FEED_HOLD_PIN, INPUT);
-  pinMode(CONTROL_CYCLE_START_PIN, INPUT);
+	attachInterrupt(digitalPinToInterrupt(CONTROL_SAFETY_DOOR_PIN), isr_control_inputs, CHANGE);
+#endif
+#ifdef CONTROL_RESET_PIN
+	pinMode(CONTROL_RESET_PIN, INPUT);
+	attachInterrupt(digitalPinToInterrupt(CONTROL_RESET_PIN), isr_control_inputs, CHANGE);
+#endif
+#ifdef CONTROL_FEED_HOLD_PIN
+	pinMode(CONTROL_FEED_HOLD_PIN, INPUT);
+	attachInterrupt(digitalPinToInterrupt(CONTROL_FEED_HOLD_PIN), isr_control_inputs, CHANGE);
+#endif
+#ifdef CONTROL_CYCLE_START_PIN
+	pinMode(CONTROL_CYCLE_START_PIN, INPUT);
+	attachInterrupt(digitalPinToInterrupt(CONTROL_CYCLE_START_PIN), isr_control_inputs, CHANGE);
+#endif
 
-  // attach interrupt to them
-  attachInterrupt(digitalPinToInterrupt(CONTROL_SAFETY_DOOR_PIN), isr_control_inputs, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(CONTROL_RESET_PIN), isr_control_inputs, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(CONTROL_FEED_HOLD_PIN), isr_control_inputs, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(CONTROL_CYCLE_START_PIN), isr_control_inputs, CHANGE); 
 }
 
 void IRAM_ATTR isr_control_inputs()
@@ -421,12 +428,19 @@ uint8_t system_control_get_state()
 	#endif
 	
 	
-  uint8_t control_state = 0;	
+  uint8_t control_state = 0;
+#ifdef CONTROL_SAFETY_DOOR_PIN
   if (digitalRead(CONTROL_SAFETY_DOOR_PIN)) { control_state |= CONTROL_PIN_INDEX_SAFETY_DOOR; } 
+#endif
+#ifdef CONTROL_RESET_PIN
   if (digitalRead(CONTROL_RESET_PIN)) { control_state |= CONTROL_PIN_INDEX_RESET; }
+#endif
+#ifdef CONTROL_FEED_HOLD_PIN
   if (digitalRead(CONTROL_FEED_HOLD_PIN)) { control_state |= CONTROL_PIN_INDEX_FEED_HOLD; }
+#endif
+#ifdef CONTROL_CYCLE_START_PIN
   if (digitalRead(CONTROL_CYCLE_START_PIN)) { control_state |= CONTROL_PIN_INDEX_CYCLE_START; }   
-	
+#endif
   #ifdef INVERT_CONTROL_PIN_MASK
     control_state ^= INVERT_CONTROL_PIN_MASK;
   #endif  

--- a/Grbl_Esp32/system.cpp
+++ b/Grbl_Esp32/system.cpp
@@ -1,6 +1,6 @@
 /*
   system.cpp - Header for system level commands and real-time processes
-  art of Grbl
+  Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 	
 	2018 -	Bart Dring This file was modified for use on the ESP32


### PR DESCRIPTION
This change allows ctrl inputs for door, hold,  resume and reset to be individually disabled, should the not be needed, or are needed for other functions.

Commenting out the pin definition in cpu_map.h will disable the input.