### PR TITLE
Add basic platformio config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.pioenvs/

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,11 @@
+[platformio]
+src_dir=Grbl_Esp32
+lib_dir=libraries
+data_dir=Grbl_Esp32/data
+
+[env:nodemcu-32s]
+platform = espressif32
+board = nodemcu-32s
+framework = arduino
+upload_speed = 512000
+


### PR DESCRIPTION
Add basic platformio config file with corresponding gitignore file.

Assuming, device is at /dev/ttyUSB4 to compile code and flash it call
> $ pio run --target=upload --upload-port=/dev/ttyUSB4

and to upload SPIFFS command would be

> $ pio run --target=uploadfs --upload-port=/dev/ttyUSB4

Note: I used for testing a ESP32-T board - using baudrate 512000 was working for SPIFFS stable enough, but for code it sometimes failed. If you have same issue, just reduce baudrate in platformio.ini e.g. to 115200.