### PR TITLE
Set partition schema for platformio using spiffs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,4 +8,4 @@ platform = espressif32
 board = nodemcu-32s
 framework = arduino
 upload_speed = 512000
-
+board_build.partitions = min_spiffs.csv


### PR DESCRIPTION
Add partition schema to solve issue when using platformio like described in issue #138.