### PR TITLE
Fix possible reference to uninitialized variables

### DIFF
--- a/Grbl_Esp32/gcode.cpp
+++ b/Grbl_Esp32/gcode.cpp
@@ -108,7 +108,7 @@ uint8_t gc_execute_line(char *line, uint8_t client)
 	   perform initial error-checks for command word modal group violations, for any repeated
 	   words, and for negative values set for the value words F, N, P, T, and S. */
 
-	uint8_t word_bit; // Bit-value for assigning tracking variables
+	uint8_t word_bit = 0; // Bit-value for assigning tracking variables
 	uint8_t char_counter;
 	char letter;
 	float value;


### PR DESCRIPTION
I would like to report on other matters.
In my environment, raising warning levels will result in compilation errors.
```
(snip)
In file included from /var/folders/tq/mmlh25c96d157qrqgtv3g36w0000gn/T/arduino_build_993650/sketch/grbl.h:36:0,
                 from /var/folders/tq/mmlh25c96d157qrqgtv3g36w0000gn/T/arduino_build_993650/sketch/config.h:40,
                 from /var/folders/tq/mmlh25c96d157qrqgtv3g36w0000gn/T/arduino_build_993650/sketch/grbl.h:35,
                 from /var/folders/tq/mmlh25c96d157qrqgtv3g36w0000gn/T/arduino_build_993650/sketch/gcode.cpp:25:
/var/folders/tq/mmlh25c96d157qrqgtv3g36w0000gn/T/arduino_build_993650/sketch/nuts_bolts.h: In function 'uint8_t gc_execute_line(char*, uint8_t)':
nuts_bolts.h:64:40: error: 'word_bit' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define bit_istrue(x,mask) ((x & mask) != 0)
                                        ^
/var/folders/tq/mmlh25c96d157qrqgtv3g36w0000gn/T/arduino_build_993650/sketch/gcode.cpp:111:10: note: 'word_bit' was declared here
  uint8_t word_bit; // Bit-value for assigning tracking variables
          ^
(snip)
```
I will propose a small code as a solution.
(It seems necessary to check multiple commands for each modal group violation)
