### PR TITLE
Add support for RC ESC based spindles

### DIFF
--- a/Grbl_Esp32/cpu_map.h
+++ b/Grbl_Esp32/cpu_map.h
@@ -85,7 +85,83 @@
 				#define SPINDLE_PWM_MIN_VALUE   1   // Must be greater than zero.
 		#endif
 		
+		#define SPINDLE_ENABLE_PIN	GPIO_NUM_22
+		
 		#define SPINDLE_PWM_RANGE         (SPINDLE_PWM_MAX_VALUE-SPINDLE_PWM_MIN_VALUE)		
+		
+		// if these spindle function pins are defined, they will be activated in the code
+		// comment them out to use the pins for other functions
+		//#define SPINDLE_ENABLE_PIN	GPIO_NUM_16
+		//#define SPINDLE_DIR_PIN			GPIO_NUM_16		
+		
+		#define X_LIMIT_PIN      	GPIO_NUM_2  
+		#define Y_LIMIT_PIN      	GPIO_NUM_4  
+		#define Z_LIMIT_PIN     	GPIO_NUM_15 	
+		#define LIMIT_MASK      	B111
+		
+		#define PROBE_PIN       	GPIO_NUM_32  
+		
+		#define CONTROL_SAFETY_DOOR_PIN   GPIO_NUM_35  // needs external pullup
+		#define CONTROL_RESET_PIN         GPIO_NUM_34  // needs external pullup
+		#define CONTROL_FEED_HOLD_PIN     GPIO_NUM_36  // needs external pullup 
+		#define CONTROL_CYCLE_START_PIN   GPIO_NUM_39  // needs external pullup    		
+		
+#endif
+
+#ifdef CPU_MAP_ESP32_ESC_SPINDLE
+	// This is the CPU Map for the ESP32 CNC Controller R2	
+	
+	  // It is OK to comment out any step and direction pins. This
+    // won't affect operation except that there will be no output
+		// form the pins. Grbl will virtually move the axis. This could 
+		// be handy if you are using a servo, etc. for another axis.
+		#define CPU_MAP_NAME "CPU_MAP_ESP32"	
+		
+		#define X_STEP_PIN      	GPIO_NUM_12
+		#define X_DIRECTION_PIN  	GPIO_NUM_26
+		#define X_RMT_CHANNEL		0
+		
+		#define Y_STEP_PIN      	GPIO_NUM_14
+		#define Y_DIRECTION_PIN   	GPIO_NUM_25
+		#define Y_RMT_CHANNEL		1
+		
+		#define Z_STEP_PIN      	GPIO_NUM_27		
+		#define Z_DIRECTION_PIN   	GPIO_NUM_33 		 
+		#define Z_RMT_CHANNEL		2		
+		
+		// OK to comment out to use pin for other features
+		#define STEPPERS_DISABLE_PIN GPIO_NUM_13		
+		
+		// *** the flood coolant feature code is activated by defining this pins
+		// *** Comment it out to use the pin for other features
+		#define COOLANT_FLOOD_PIN 	GPIO_NUM_16			
+		//#define COOLANT_MIST_PIN   	GPIO_NUM_21
+		
+		// If SPINDLE_PWM_PIN is commented out, this frees up the pin, but Grbl will still
+		// use a virtual spindle. Do not comment out the other parameters for the spindle.
+		#define SPINDLE_PWM_PIN    GPIO_NUM_17 
+		#define SPINDLE_PWM_CHANNEL 0
+		
+		// RC ESC Based Spindle 
+		// An ESC works like a hobby servo with 50Hz PWM 1ms to 2 ms pulse range		
+		#define SPINDLE_PWM_BASE_FREQ 50 // Hz for ESC
+		#define SPINDLE_PWM_BIT_PRECISION 16   // 16 bit required for ESC
+		#define SPINDLE_PULSE_RES_COUNT 65535
+		
+		#define ESC_MIN_PULSE_SEC 0.001 // min pulse in seconds (OK to tune this one)
+		#define ESC_MAX_PULSE_SEC 0.002 // max pulse in seconds (OK to tune this one)		
+		#define ESC_TIME_PER_BIT  ((1.0 / (float)SPINDLE_PWM_BASE_FREQ) / ((float)SPINDLE_PULSE_RES_COUNT) ) // seconds
+
+		#define SPINDLE_PWM_OFF_VALUE    (uint16_t)(SERVO_MIN_PULSE_SEC / SERVO_TIME_PER_BIT) // in timer counts
+		#define SPINDLE_PWM_MAX_VALUE    (uint16_t)(SERVO_MAX_PULSE_SEC / SERVO_TIME_PER_BIT) // in timer counts
+		
+		#ifndef SPINDLE_PWM_MIN_VALUE
+				#define SPINDLE_PWM_MIN_VALUE   SPINDLE_PWM_OFF_VALUE   // Must be greater than zero.
+		#endif
+		
+		#define SPINDLE_PWM_RANGE         (SPINDLE_PWM_MAX_VALUE-SPINDLE_PWM_MIN_VALUE)
+		
+		#define SPINDLE_ENABLE_PIN	GPIO_NUM_22			
 		
 		// if these spindle function pins are defined, they will be activated in the code
 		// comment them out to use the pins for other functions
@@ -709,7 +785,7 @@
 		#define USE_SPINDLE_RELAY
 		
 		#ifdef USE_SPINDLE_RELAY		
-			#define SPINDLE_PWM_PIN    GPIO_NUM_17
+			#define SPINDLE_PWM_PIN    GPIO_NUM_2
 		#else
 			#define SPINDLE_PWM_PIN    GPIO_NUM_16
 			#define SPINDLE_ENABLE_PIN	GPIO_NUM_32
@@ -736,7 +812,7 @@
 		// Relay can be used for Spindle or Coolant
 		//#define COOLANT_FLOOD_PIN 	GPIO_NUM_17
 		
-		#define X_LIMIT_PIN      	GPIO_NUM_2  
+		#define X_LIMIT_PIN      	GPIO_NUM_17 
 		#define Y_LIMIT_PIN      	GPIO_NUM_4  
 		#define Z_LIMIT_PIN     	GPIO_NUM_15 	
 		#define LIMIT_MASK      	B111
@@ -785,7 +861,7 @@
 		
 				
 		// Note: if you use PWM rather than relay, you could map GPIO_NUM_17 to mist or flood 
-		//#define USE_SPINDLE_RELAY
+		#define USE_SPINDLE_RELAY
 		
 		#ifdef USE_SPINDLE_RELAY		
 			#define SPINDLE_PWM_PIN    GPIO_NUM_17

--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -20,7 +20,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1f"
-#define GRBL_VERSION_BUILD "20180917"
+#define GRBL_VERSION_BUILD "20190517"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/spindle_control.cpp
+++ b/Grbl_Esp32/spindle_control.cpp
@@ -49,7 +49,7 @@ void spindle_stop()
 {		
   spindle_set_enable(false);
 	#ifdef SPINDLE_PWM_PIN
-		grbl_analogWrite(SPINDLE_PWM_CHANNEL, 0);	
+		grbl_analogWrite(SPINDLE_PWM_CHANNEL, SPINDLE_PWM_OFF_VALUE);
 	#endif
 }
 


### PR DESCRIPTION
- Change spindle_stop() off value from 0 to SPINDLE_PWM_OFF_VALUE
- Add example cpu_map.h  CPU_MAP_ESP32_ESC_SPINDLE