### PR TITLE
Create a V1P2 cpu_map of the MPCNC

### DIFF
--- a/Grbl_Esp32/cpu_map.h
+++ b/Grbl_Esp32/cpu_map.h
@@ -749,10 +749,10 @@
 		
 #endif
 
-#ifdef CPU_MAP_MPCNC
+#ifdef CPU_MAP_MPCNC_V1P2
 	// This is the CPU Map for the Buildlog.net MPCNC controller
 	
-		#define CPU_MAP_NAME "CPU_MAP_MPCNC"
+		#define CPU_MAP_NAME "CPU_MAP_MPCNC_V1P2"
 	
 		// switch to the correct default settings
 		#ifdef DEFAULTS_GENERIC
@@ -778,11 +778,10 @@
 		#define Z_DIRECTION_PIN   GPIO_NUM_33 
 		
 		// OK to comment out to use pin for other features
-		#define STEPPERS_DISABLE_PIN GPIO_NUM_13		
-		
+		#define STEPPERS_DISABLE_PIN GPIO_NUM_13				
 				
-		// Note: if you use PWM rather than relay, you could map GPIO_NUM_17 to mist or flood 
-		#define USE_SPINDLE_RELAY
+		// Note: if you use PWM rather than relay, you could map GPIO_NUM_2 to mist or flood 
+		//#define USE_SPINDLE_RELAY
 		
 		#ifdef USE_SPINDLE_RELAY		
 			#define SPINDLE_PWM_PIN    GPIO_NUM_2
@@ -810,12 +809,16 @@
 		
 		// Note: Only uncomment this if USE_SPINDLE_RELAY is commented out.
 		// Relay can be used for Spindle or Coolant
-		//#define COOLANT_FLOOD_PIN 	GPIO_NUM_17
+		//#define COOLANT_FLOOD_PIN 	GPIO_NUM_2
 		
 		#define X_LIMIT_PIN      	GPIO_NUM_17 
 		#define Y_LIMIT_PIN      	GPIO_NUM_4  
 		#define Z_LIMIT_PIN     	GPIO_NUM_15 	
 		#define LIMIT_MASK      	B111
+		
+		#ifndef ENABLE_SOFTWARE_DEBOUNCE   // V1P2 does not have R/C filters
+			#define ENABLE_SOFTWARE_DEBOUNCE
+		#endif
 		
 		#define PROBE_PIN       	GPIO_NUM_35  
 		
@@ -826,7 +829,15 @@
 		
 		#define INVERT_CONTROL_PIN_MASK   B1110
 		
-		// Note: check the #define IGNORE_CONTROL_PINS is the way you want in config.h
+		// Note: defualt is #define IGNORE_CONTROL_PINS in config.h
+		// uncomment to these lines to use them		
+		#ifdef IGNORE_CONTROL_PINS
+			#undef IGNORE_CONTROL_PINS
+		#endif
+		
+		
+		
+		
 		#define CONTROL_RESET_PIN         GPIO_NUM_34  // needs external pullup
 		#define CONTROL_FEED_HOLD_PIN     GPIO_NUM_36  // needs external pullup 
 		#define CONTROL_CYCLE_START_PIN   GPIO_NUM_39  // needs external pullup    		
@@ -896,7 +907,7 @@
 		// Relay can be used for Spindle or Coolant
 		//#define COOLANT_FLOOD_PIN 	GPIO_NUM_17
 		
-		#define X_LIMIT_PIN      	GPIO_NUM_2 
+		#define X_LIMIT_PIN      	GPIO_NUM_34 
 		#define Y_LIMIT_PIN      	GPIO_NUM_4  
 		#define Z_LIMIT_PIN     	GPIO_NUM_15 	
 		#define LIMIT_MASK      	B111
@@ -908,10 +919,10 @@
 			#undef INVERT_CONTROL_PIN_MASK			
 		#endif
 		
-		#define INVERT_CONTROL_PIN_MASK   B1110
+		#define INVERT_CONTROL_PIN_MASK   B1100
 		
 		// Note: check the #define IGNORE_CONTROL_PINS is the way you want in config.h
-		#define CONTROL_RESET_PIN         GPIO_NUM_34  // needs external pullup
+		//#define CONTROL_RESET_PIN         GPIO_NUM_34  // needs external pullup
 		#define CONTROL_FEED_HOLD_PIN     GPIO_NUM_36  // needs external pullup 
 		#define CONTROL_CYCLE_START_PIN   GPIO_NUM_39  // needs external pullup    		
 		

--- a/Grbl_Esp32/defaults.h
+++ b/Grbl_Esp32/defaults.h
@@ -83,53 +83,58 @@
 #endif
 
 #ifdef DEFAULTS_MPCNC
-  // Grbl generic default settings. Should work across different machines.
-  #define DEFAULT_STEP_PULSE_MICROSECONDS 3 
-  #define DEFAULT_STEPPER_IDLE_LOCK_TIME 255 //  255 = Keep steppers on 
-  
-  #define DEFAULT_STEPPING_INVERT_MASK 0 // uint8_t
-  #define DEFAULT_DIRECTION_INVERT_MASK 0 // uint8_t
-   #define DEFAULT_INVERT_ST_ENABLE 0 // boolean
-  #define DEFAULT_INVERT_LIMIT_PINS 1 // boolean
-  #define DEFAULT_INVERT_PROBE_PIN 0 // boolean 
-  
-  #define DEFAULT_STATUS_REPORT_MASK 1
-  
-  #define DEFAULT_JUNCTION_DEVIATION 0.01 // mm
-  #define DEFAULT_ARC_TOLERANCE 0.002 // mm
-  #define DEFAULT_REPORT_INCHES 0 // false
-  
-  #define DEFAULT_SOFT_LIMIT_ENABLE 0 // false
-  #define DEFAULT_HARD_LIMIT_ENABLE 0  // false
-  
-  #define DEFAULT_HOMING_ENABLE 1  // false
-  #define DEFAULT_HOMING_DIR_MASK 3 // move positive dir Z,negative X,Y
-  #define DEFAULT_HOMING_FEED_RATE 600.0 // mm/min
-  #define DEFAULT_HOMING_SEEK_RATE 2000.0 // mm/min
-  #define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
-  #define DEFAULT_HOMING_PULLOFF 1.5 // mm
+	// Grbl generic default settings. Should work across different machines.
+	#define DEFAULT_STEP_PULSE_MICROSECONDS 3 
+	#define DEFAULT_STEPPER_IDLE_LOCK_TIME 255 //  255 = Keep steppers on 
 
-  #define DEFAULT_SPINDLE_RPM_MAX 1.0 // rpm used for spindle relay
-  #define DEFAULT_SPINDLE_RPM_MIN 0.0 // rpm
-  
-  #define DEFAULT_LASER_MODE 0 // false
-  
-  #define DEFAULT_X_STEPS_PER_MM 200.0
-  #define DEFAULT_Y_STEPS_PER_MM 200.0
-  #define DEFAULT_Z_STEPS_PER_MM 800.0
-  
-  #define DEFAULT_X_MAX_RATE 8000.0 // mm/min
-  #define DEFAULT_Y_MAX_RATE 8000.0 // mm/min
-  #define DEFAULT_Z_MAX_RATE 3000.0 // mm/min
-  
-  #define DEFAULT_X_ACCELERATION (200.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
-  #define DEFAULT_Y_ACCELERATION (200.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
-  #define DEFAULT_Z_ACCELERATION (100.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
-  
-  #define DEFAULT_X_MAX_TRAVEL 500.0 // mm NOTE: Must be a positive value.
-  #define DEFAULT_Y_MAX_TRAVEL 500.0 // mm NOTE: Must be a positive value.
-  #define DEFAULT_Z_MAX_TRAVEL 80.0 // mm NOTE: Must be a positive value.
-  
+	#define DEFAULT_STEPPING_INVERT_MASK 0 // uint8_t
+	#define DEFAULT_DIRECTION_INVERT_MASK 0 // uint8_t
+	#define DEFAULT_INVERT_ST_ENABLE 0 // boolean
+	#define DEFAULT_INVERT_LIMIT_PINS 1 // boolean
+	#define DEFAULT_INVERT_PROBE_PIN 0 // boolean 
+
+	#define DEFAULT_STATUS_REPORT_MASK 1
+
+	#define DEFAULT_JUNCTION_DEVIATION 0.01 // mm
+	#define DEFAULT_ARC_TOLERANCE 0.002 // mm
+	#define DEFAULT_REPORT_INCHES 0 // false
+
+	#define DEFAULT_SOFT_LIMIT_ENABLE 0 // false
+	#define DEFAULT_HARD_LIMIT_ENABLE 0  // false
+
+	#define DEFAULT_HOMING_ENABLE 1  // false
+	#define DEFAULT_HOMING_DIR_MASK 3 // move positive dir Z,negative X,Y
+	#define DEFAULT_HOMING_FEED_RATE 600.0 // mm/min
+	#define DEFAULT_HOMING_SEEK_RATE 2000.0 // mm/min
+	#define DEFAULT_HOMING_DEBOUNCE_DELAY 250 // msec (0-65k)
+	#define DEFAULT_HOMING_PULLOFF 1.5 // mm
+
+	#ifdef USE_SPINDLE_RELAY
+		#define DEFAULT_SPINDLE_RPM_MAX 1.0 // must be 1 so PWM duty is alway 100% to prevent relay damage
+	#else
+		#define DEFAULT_SPINDLE_RPM_MAX 1000.0 // can be change to your spindle max
+	#endif	
+		
+	#define DEFAULT_SPINDLE_RPM_MIN 0.0 // rpm
+
+	#define DEFAULT_LASER_MODE 0 // false
+
+	#define DEFAULT_X_STEPS_PER_MM 200.0
+	#define DEFAULT_Y_STEPS_PER_MM 200.0
+	#define DEFAULT_Z_STEPS_PER_MM 800.0
+
+	#define DEFAULT_X_MAX_RATE 8000.0 // mm/min
+	#define DEFAULT_Y_MAX_RATE 8000.0 // mm/min
+	#define DEFAULT_Z_MAX_RATE 3000.0 // mm/min
+
+	#define DEFAULT_X_ACCELERATION (200.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+	#define DEFAULT_Y_ACCELERATION (200.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+	#define DEFAULT_Z_ACCELERATION (100.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+
+	#define DEFAULT_X_MAX_TRAVEL 500.0 // mm NOTE: Must be a positive value.
+	#define DEFAULT_Y_MAX_TRAVEL 500.0 // mm NOTE: Must be a positive value.
+	#define DEFAULT_Z_MAX_TRAVEL 80.0 // mm NOTE: Must be a positive value.
+
 
 #endif
 


### PR DESCRIPTION
- Moves a few pins around. Primarily to fix issues with GPIO2 being an input on some dev modules.