### PR TITLE
Homing set machine origin to bottom left

### DIFF
--- a/Grbl_Esp32/config.h
+++ b/Grbl_Esp32/config.h
@@ -193,6 +193,9 @@ Some features should not be changed. See notes below.
 // define to force Grbl to always set the machine origin at the homed location despite switch orientation.
 // #define HOMING_FORCE_SET_ORIGIN // Uncomment to enable.
 
+// Uncomment this define to force Grbl to always set the machine origin at bottom left.
+#define HOMING_FORCE_POSITIVE_SPACE // Uncomment to enable.
+
 // Number of blocks Grbl executes upon startup. These blocks are stored in EEPROM, where the size
 // and addresses are defined in settings.h. With the current settings, up to 2 startup blocks may
 // be stored and executed in order. These startup blocks would typically be used to set the g-code

--- a/Grbl_Esp32/config.h
+++ b/Grbl_Esp32/config.h
@@ -194,7 +194,7 @@ Some features should not be changed. See notes below.
 // #define HOMING_FORCE_SET_ORIGIN // Uncomment to enable.
 
 // Uncomment this define to force Grbl to always set the machine origin at bottom left.
-#define HOMING_FORCE_POSITIVE_SPACE // Uncomment to enable.
+// #define HOMING_FORCE_POSITIVE_SPACE // Uncomment to enable.
 
 // Number of blocks Grbl executes upon startup. These blocks are stored in EEPROM, where the size
 // and addresses are defined in settings.h. With the current settings, up to 2 startup blocks may

--- a/Grbl_Esp32/grbl_limits.cpp
+++ b/Grbl_Esp32/grbl_limits.cpp
@@ -239,9 +239,17 @@ void limits_go_home(uint8_t cycle_mask)
         set_axis_position = 0;
       #else
         if ( bit_istrue(settings.homing_dir_mask,bit(idx)) ) {
-          set_axis_position = lround((settings.max_travel[idx]+settings.homing_pulloff)*settings.steps_per_mm[idx]);
+          #ifdef HOMING_FORCE_POSITIVE_SPACE
+            set_axis_position = 0; //lround(settings.homing_pulloff*settings.steps_per_mm[idx]);
+          #else
+            set_axis_position = lround((settings.max_travel[idx]+settings.homing_pulloff)*settings.steps_per_mm[idx]);
+          #endif
         } else {
-          set_axis_position = lround(-settings.homing_pulloff*settings.steps_per_mm[idx]);
+          #ifdef HOMING_FORCE_POSITIVE_SPACE
+            set_axis_position = lround((-settings.max_travel[idx]-settings.homing_pulloff)*settings.steps_per_mm[idx]);
+          #else
+            set_axis_position = lround(-settings.homing_pulloff*settings.steps_per_mm[idx]);
+          #endif
         }
       #endif
 

--- a/Grbl_Esp32/system.cpp
+++ b/Grbl_Esp32/system.cpp
@@ -425,7 +425,11 @@ uint8_t system_check_travel_limits(float *target)
       }
     #else
       // NOTE: max_travel is stored as negative
-      if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
+      #ifdef HOMING_FORCE_POSITIVE_SPACE
+        if (target[idx] < 0 || target[idx] > -settings.max_travel[idx]) { return(true); }
+      #else
+        if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
+        ndif
     #endif
   }
   return(false);


### PR DESCRIPTION
The new config switch HOMING_FORCE_POSITIVE_SPACE sets the machine origin after homing to bottom left (independent of homing switch position, which is set by $23).