### PR TITLE
Do not send pwm info messages to serial

### DIFF
--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -20,7 +20,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1f"
-#define GRBL_VERSION_BUILD "20191105"
+#define GRBL_VERSION_BUILD "20191113"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/spindle_control.cpp
+++ b/Grbl_Esp32/spindle_control.cpp
@@ -212,7 +212,8 @@ void grbl_analogWrite(uint8_t chan, uint32_t duty)
 {
 	if (ledcRead(chan) != duty) // reduce unnecessary calls to ledcWrite()
 	{
-		grbl_sendf(CLIENT_SERIAL, "[MSG: grbl_analogWrite %d]\r\n", duty);
+		// Useful for debug, but too many messages in laser mode
+		// grbl_sendf(CLIENT_SERIAL, "[MSG: grbl_analogWrite %d]\r\n", duty);
 		ledcWrite(chan, duty);
 	}
 }


### PR DESCRIPTION
Simple PR to address the (?debug) messages announcing each PWM power change with:
`[MSG: grbl_analogWrite nnn]`
With LaserWeb these were overwhelming the serial output during rapid laser mode commands. I assume they were put in to assist development of th enew spindle and PWM mapping, but I think they should be commented out for normal use.