### PR TITLE
Strip out USE_SPINDLE_DIR_AS_ENABLE_PIN references

### DIFF
--- a/Grbl_Esp32/config.h
+++ b/Grbl_Esp32/config.h
@@ -297,9 +297,6 @@ Some features should not be changed. See notes below.
 
 // Inverts the spindle enable pin from low-disabled/high-enabled to low-enabled/high-disabled. Useful
 // for some pre-built electronic boards.
-// NOTE: If VARIABLE_SPINDLE is enabled(default), this option has no effect as the PWM output and
-// spindle enable are combined to one pin. If you need both this option and spindle speed PWM,
-// uncomment the config option USE_SPINDLE_DIR_AS_ENABLE_PIN below.
 // #define INVERT_SPINDLE_ENABLE_PIN // Default disabled. Uncomment to enable.
 
 // Inverts the selected coolant pin from low-disabled/high-enabled to low-enabled/high-disabled. Useful
@@ -430,25 +427,12 @@ Some features should not be changed. See notes below.
 // The hardware PWM output on pin D11 is required for variable spindle output voltages.
 #define VARIABLE_SPINDLE // Default enabled. Comment to disable.
 
-
-
-// By default on a 328p(Uno), Grbl combines the variable spindle PWM and the enable into one pin to help
-// preserve I/O pins. For certain setups, these may need to be separate pins. This configure option uses
-// the spindle direction pin(D13) as a separate spindle enable pin along with spindle speed PWM on pin D11.
-// NOTE: This configure option only works with VARIABLE_SPINDLE enabled and a 328p processor (Uno).
-// NOTE: Without a direction pin, M4 will not have a pin output to indicate a difference with M3. 
-// NOTE: BEWARE! The Arduino bootloader toggles the D13 pin when it powers up. If you flash Grbl with
-// a programmer (you can use a spare Arduino as "Arduino as ISP". Search the web on how to wire this.),
-// this D13 LED toggling should go away. We haven't tested this though. Please report how it goes!
-// #define USE_SPINDLE_DIR_AS_ENABLE_PIN // Default disabled. Uncomment to enable.
-
-// Alters the behavior of the spindle enable pin with the USE_SPINDLE_DIR_AS_ENABLE_PIN option . By default,
-// Grbl will not disable the enable pin if spindle speed is zero and M3/4 is active, but still sets the PWM 
-// output to zero. This allows the users to know if the spindle is active and use it as an additional control
-// input. However, in some use cases, user may want the enable pin to disable with a zero spindle speed and 
+// Alters the behavior of the spindle enable pin. By default Grbl will not disable the enable pin if 
+// spindle speed is zero and M3/4 is active, but still sets the PWM output to zero. This allows the users 
+// to know if the spindle is active and use it as an additional control input.
+// However, in some use cases, user may want the enable pin to disable with a zero spindle speed and 
 // re-enable when spindle speed is greater than zero. This option does that.
-// NOTE: Requires USE_SPINDLE_DIR_AS_ENABLE_PIN to be enabled.
-#define SPINDLE_ENABLE_OFF_WITH_ZERO_SPEED // Default disabled. Uncomment to enable.
+#define SPINDLE_ENABLE_OFF_WITH_ZERO_SPEED // Default enabled. Comment to disable.
 
 // With this enabled, Grbl sends back an echo of the line it has received, which has been pre-parsed (spaces
 // removed, capitalized letters, no comments) and is to be immediately executed by Grbl. Echoes will not be

--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -20,7 +20,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1f"
-#define GRBL_VERSION_BUILD "20191105"
+#define GRBL_VERSION_BUILD "20191113"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/report.cpp
+++ b/Grbl_Esp32/report.cpp
@@ -813,17 +813,8 @@ void report_realtime_status(uint8_t client)
       if (sp_state || cl_state) {
         strcat(status, "|A:");
         if (sp_state) { // != SPINDLE_STATE_DISABLE
-          #ifdef VARIABLE_SPINDLE 
-            #ifdef USE_SPINDLE_DIR_AS_ENABLE_PIN
-              strcat(status, "S"); // CW
-            #else
-              if (sp_state == SPINDLE_STATE_CW) { strcat(status, "S"); } // CW
-              else { strcat(status, "C"); } // CCW
-            #endif
-          #else
-            if (sp_state & SPINDLE_STATE_CW) { strcat(status, "S"); } // CW
-            else { strcat(status, "C"); } // CCW
-          #endif
+          if (sp_state == SPINDLE_STATE_CW) { strcat(status, "S"); } // CW
+          else { strcat(status, "C"); } // CCW
         }
         if (cl_state & COOLANT_STATE_FLOOD) { strcat(status, "F"); }
         #ifdef COOLANT_MIST_PIN // TODO Deal with M8 - Flood


### PR DESCRIPTION
`USE_SPINDLE_DIR_AS_ENABLE_PIN` is a hangup from ATMega328 days where pins needed to be carefully assigned, GRBL-ESP32 has largely moved to a flexible pin map and this setting no longer does anything practical. But still clutters up config.h in confusing ways..