### PR TITLE
Fix: sync internal variables after kinematics_homing

### DIFF
--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -20,7 +20,7 @@
 
 // Grbl versioning system
 #define GRBL_VERSION "1.1f"
-#define GRBL_VERSION_BUILD "20191113"
+#define GRBL_VERSION_BUILD "20191201"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/motion_control.cpp
+++ b/Grbl_Esp32/motion_control.cpp
@@ -241,8 +241,9 @@ void mc_homing_cycle(uint8_t cycle_mask)
 	// This give kinematics a chance to do something before normal homing
 	// if it returns true, the homing is canceled.
 	#ifdef USE_KINEMATICS
-		if (!kinematics_homing(cycle_mask))
-			return;
+		if (kinematics_pre_homing(cycle_mask)) {
+ 			return;
+   }
 	#endif
 	
   // Check and abort homing cycle, if hard limits are already enabled. Helps prevent problems
@@ -329,6 +330,11 @@ void mc_homing_cycle(uint8_t cycle_mask)
   // Sync gcode parser and planner positions to homed position.
   gc_sync_position();
   plan_sync_position();
+
+	#ifdef USE_KINEMATICS
+	// This give kinematics a chance to do something after normal homing
+  kinematics_post_homing();
+	#endif
 
   // If hard limits feature enabled, re-enable hard limits pin change register after homing cycle.
   limits_init();

--- a/Grbl_Esp32/polar_coaster.cpp
+++ b/Grbl_Esp32/polar_coaster.cpp
@@ -65,7 +65,9 @@ bool kinematics_pre_homing(uint8_t cycle_mask)
 	
 	// zero the axes that are not homed
 	sys_position[Y_AXIS] = 0.0f; 
-	//sys_position[Z_AXIS] = 0.0f; // do not zero Z axis to prevent the pen from moving down
+
+    // Move pen up.
+    sys_position[Z_AXIS] = SERVO_Z_RANGE_MAX * settings.steps_per_mm[Z_AXIS];
 
 	return false; // do not skip the rest of homing cycle
 }

--- a/Grbl_Esp32/polar_coaster.cpp
+++ b/Grbl_Esp32/polar_coaster.cpp
@@ -225,7 +225,7 @@ void calc_polar(float *target_xyz, float *polar, float last_angle)
 	
 	//grbl_sendf(CLIENT_SERIAL, "calc polar: x...%4.2f y...%4.2f\r\n", target_xyz[X_AXIS], target_xyz[Y_AXIS]);
 	
-	target_xyz[X_AXIS] *= -1.0;   // compensate for Polar Coaster's radial axis being mirrored (right side) from normal 0deg
+	//target_xyz[X_AXIS] *= -1.0;   // compensate for Polar Coaster's radial axis being mirrored (right side) from normal 0deg
 	
 	polar[RADIUS_AXIS] = hypot_f(target_xyz[X_AXIS], target_xyz[Y_AXIS]);
 	

--- a/Grbl_Esp32/polar_coaster.h
+++ b/Grbl_Esp32/polar_coaster.h
@@ -29,7 +29,8 @@
     
 	#include "grbl.h"
 		
-bool kinematics_homing(uint8_t cycle_mask);
+bool kinematics_pre_homing(uint8_t cycle_mask);
+void kinematics_post_homing();
 void inverse_kinematics(float *target, plan_line_data_t *pl_data, float *position);
 void calc_polar(float *target_xyz, float *polar, float last_angle);
 void user_defined_macro(uint8_t index);


### PR DESCRIPTION
Hi, Bert-san.

Please merge my chages about kinematics homing.

1) After kinematics_homing, polar angle has increased (not synchronized). To correct this phenomenon, reset the internal value when the homing cycle is complete.

2) The kinematics_homing function should return True if it want to skip the subsequent homing process (according to comments in the source)

3) I thought that the homing function can be processed flexibly if it is executed before and after the original homing process.

4) Fix the Polar Coaster's drawing being mirrored. (uncomment the code)

Thanks.