### PR TITLE
Simple speedup for spindle PWM

### DIFF
--- a/Grbl_Esp32/spindle_control.cpp
+++ b/Grbl_Esp32/spindle_control.cpp
@@ -205,8 +205,14 @@ void spindle_sync(uint8_t state, float rpm)
 
 void grbl_analogWrite(uint8_t chan, uint32_t duty)
 {
-	if (ledcRead(chan) != duty) // reduce unnecessary calls to ledcWrite()
+	// Remember the old duty cycle in memory instead of reading
+	// it from the I/O peripheral because I/O reads are quite
+	// a bit slower than memory reads.
+	static uint32_t old_duty = 0;
+
+	if (old_duty != duty) // reduce unnecessary calls to ledcWrite()
 	{		
+		old_duty = duty;
 		ledcWrite(chan, duty);
 	}
 }


### PR DESCRIPTION
This is the opening salvo in an effort to improve the performance of PWM by optimizing the driver code for the ESP32's LED PWM hardware.  In this first checkin, we simply avoid the need to call ledcRead() by saving the old duty cycle value in memory, thus avoiding both a function call and an I/O read operation - as I/O reads cost lots of CPU cycles compared to memory reads.