### PR TITLE
Auto squaring improvement

### DIFF
--- a/Grbl_Esp32/grbl_limits.cpp
+++ b/Grbl_Esp32/grbl_limits.cpp
@@ -27,6 +27,8 @@
 
 #include "grbl.h"
 
+uint8_t n_homing_locate_cycle = N_HOMING_LOCATE_CYCLE;
+
 xQueueHandle limit_sw_queue;  // used by limit switch debouncing
 
 // Homing axis search distance multiplier. Computed by this value times the cycle travel.
@@ -89,7 +91,7 @@ void limits_go_home(uint8_t cycle_mask)
   #endif
 
   // Initialize variables used for homing computations.
-  uint8_t n_cycle = (2*N_HOMING_LOCATE_CYCLE+1);
+  uint8_t n_cycle = (2*n_homing_locate_cycle+1);
   uint8_t step_pin[N_AXIS];
   float target[N_AXIS];
   float max_travel = 0.0;

--- a/Grbl_Esp32/grbl_limits.h
+++ b/Grbl_Esp32/grbl_limits.h
@@ -28,6 +28,8 @@
 #ifndef grbl_limits_h
 #define grbl_limits_h
 
+extern uint8_t n_homing_locate_cycle;
+
 #define SQUARING_MODE_DUAL	0  // both motors run
 #define SQUARING_MODE_A			1  // A motor runs
 #define SQUARING_MODE_B			2  // B motor runs

--- a/Grbl_Esp32/motion_control.cpp
+++ b/Grbl_Esp32/motion_control.cpp
@@ -244,7 +244,7 @@ void mc_homing_cycle(uint8_t cycle_mask)
 		if (kinematics_pre_homing(cycle_mask)) {
  			return;
 		}
-	#endif
+	#endif  
 	
   // Check and abort homing cycle, if hard limits are already enabled. Helps prevent problems
   // with machines with limits wired on both ends of travel to one limit pin.
@@ -262,6 +262,8 @@ void mc_homing_cycle(uint8_t cycle_mask)
   // -------------------------------------------------------------------------------------
   // Perform homing routine. NOTE: Special motion case. Only system reset works.
   
+  n_homing_locate_cycle = N_HOMING_LOCATE_CYCLE;
+
   #ifdef HOMING_SINGLE_AXIS_COMMANDS
     /*
     if (cycle_mask) { limits_go_home(cycle_mask); } // Perform homing cycle based on mask.
@@ -272,8 +274,10 @@ void mc_homing_cycle(uint8_t cycle_mask)
 			  limits_go_home(cycle_mask);  // Homing cycle 0
 	    else {
         ganged_mode = SQUARING_MODE_DUAL;
+        n_homing_locate_cycle = 0; // don't do a second touch cycle
         limits_go_home(cycle_mask);
         ganged_mode = SQUARING_MODE_A;
+        n_homing_locate_cycle = N_HOMING_LOCATE_CYCLE; // restore to default value
         limits_go_home(cycle_mask);
         ganged_mode = SQUARING_MODE_B;
         limits_go_home(cycle_mask);
@@ -289,8 +293,10 @@ void mc_homing_cycle(uint8_t cycle_mask)
 			limits_go_home(HOMING_CYCLE_0);  // Homing cycle 0
 	  else {
 			ganged_mode = SQUARING_MODE_DUAL;
+      n_homing_locate_cycle = 0; // don't do a second touch cycle
 			limits_go_home(HOMING_CYCLE_0);
 			ganged_mode = SQUARING_MODE_A;
+      n_homing_locate_cycle = N_HOMING_LOCATE_CYCLE; // restore to default value
 			limits_go_home(HOMING_CYCLE_0);
 			ganged_mode = SQUARING_MODE_B;
 			limits_go_home(HOMING_CYCLE_0);
@@ -302,8 +308,10 @@ void mc_homing_cycle(uint8_t cycle_mask)
       limits_go_home(HOMING_CYCLE_1);
 		else {
 			ganged_mode = SQUARING_MODE_DUAL;
+      n_homing_locate_cycle = 0; // don't do a second touch cycle
 			limits_go_home(HOMING_CYCLE_1);
 			ganged_mode = SQUARING_MODE_A;
+      n_homing_locate_cycle = N_HOMING_LOCATE_CYCLE; // restore to default value
 			limits_go_home(HOMING_CYCLE_1);
 			ganged_mode = SQUARING_MODE_B;
 			limits_go_home(HOMING_CYCLE_1);
@@ -316,8 +324,10 @@ void mc_homing_cycle(uint8_t cycle_mask)
       limits_go_home(HOMING_CYCLE_2);
 		else {
 			ganged_mode = SQUARING_MODE_DUAL;
+      n_homing_locate_cycle = 0; // don't do a second touch cycle
 			limits_go_home(HOMING_CYCLE_2);
 			ganged_mode = SQUARING_MODE_A;
+       n_homing_locate_cycle = N_HOMING_LOCATE_CYCLE; // restore to default value
 			limits_go_home(HOMING_CYCLE_2);
 			ganged_mode = SQUARING_MODE_B;
 			limits_go_home(HOMING_CYCLE_2);


### PR DESCRIPTION
When squaring axes the first motion with both motors will only do a seek move and a back off, rather than a seek, back off plus a locate, back off squence.

This speeds up the homing sequence. The dual move does not need a locate cycle, because each side will get a locate cycle when they are individually homed.