### PR TITLE
I2C Expander for Miroslav Zuzelka

### DIFF
--- a/Grbl_Esp32/Custom/pick_place.cpp
+++ b/Grbl_Esp32/Custom/pick_place.cpp
@@ -1,0 +1,205 @@
+/*
+	custom_code_template.cpp (copy and use your machine name)
+	Part of Grbl_ESP32
+
+	copyright (c) 2020 -	Bart Dring. This file was intended for use on the ESP32
+
+  ...add your date and name here.
+
+	CPU. Do not use this with Grbl for atMega328P
+
+	Grbl_ESP32 is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Grbl_ESP32 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+
+	=======================================================================
+
+This is a template for user-defined C++ code functions.  Grbl can be
+configured to call some optional functions, enabled by #define statements
+in the machine definition .h file.  Implement the functions thus enabled
+herein.  The possible functions are listed and described below.
+
+To use this file, copy it to a name of your own choosing, and also copy
+Machines/template.h to a similar name.
+
+Example:
+Machines/my_machine.h
+Custom/my_machine.cpp
+
+Edit machine.h to include your Machines/my_machine.h file
+
+Edit Machines/my_machine.h according to the instructions therein.
+
+Fill in the function definitions below for the functions that you have
+enabled with USE_ defines in Machines/my_machine.h
+
+===============================================================================
+
+*/
+
+#include <PCF8574.h>  // https://github.com/xreef/PCF8574_library
+
+#ifdef USE_IO_EXPANDER
+
+PCF8574 expander[] = {
+  PCF8574(0x38),
+  PCF8574(0x39),
+};
+
+#define MAX_PIN 64
+void IRAM_ATTR expanderPinMode(uint8_t pin, uint8_t val)
+{
+  if (pin >= MAX_PIN) {
+    if (val == INPUT) {
+      // PCF8574 is actively driven only low, so to allow
+      // a pin to be used as an input, you set it high.
+      expander[(pin/MAX_PIN)-1].write(pin%MAX_PIN, 1);
+    }
+    return;
+  }
+  pinMode(pin, val);
+}
+
+void IRAM_ATTR expanderDigitalWrite(uint8_t pin, uint8_t val)
+{
+  if (pin >= MAX_PIN) {
+    expander[(pin/MAX_PIN)-1].write(pin%MAX_PIN, val);
+    return;
+  }
+  digitalWrite(pin, val);
+}
+#endif
+
+#ifdef USE_MACHINE_INIT
+/*
+machine_init() is called when Grbl_ESP32 first starts. You can use it to do any
+special things your machine needs at startup.
+*/
+void machine_init()
+{
+}
+#endif
+
+#ifdef USE_CUSTOM_HOMING
+/*
+  user_defined_homing() is called at the begining of the normal Grbl_ESP32 homing
+  sequence.  If user_defined_homing() returns false, the rest of normal Grbl_ESP32
+  homing is skipped if it returns false, other normal homing continues.  For
+  example, if you need to manually prep the machine for homing, you could implement
+  user_defined_homing() to wait for some button to be pressed, then return true.
+*/
+bool user_defined_homing()
+{
+  // True = done with homing, false = continue with normal Grbl_ESP32 homing
+  return true;
+}
+#endif
+
+#ifdef USE_KINEMATICS
+/*
+  Inverse Kinematics converts X,Y,Z cartesian coordinate to the steps
+  on your "joint" motors.  It requires the following three functions:
+*/
+
+/*
+  inverse_kinematics() looks at incoming move commands and modifies
+  them before Grbl_ESP32 puts them in the motion planner.
+
+  Grbl_ESP32 processes arcs by converting them into tiny little line segments.
+  Kinematics in Grbl_ESP32 works the same way. Search for this function across
+  Grbl_ESP32 for examples. You are basically converting cartesian X,Y,Z... targets to
+
+    target = an N_AXIS array of target positions (where the move is supposed to go)
+    pl_data = planner data (see the definition of this type to see what it is)
+    position = an N_AXIS array of where the machine is starting from for this move
+*/
+void inverse_kinematics(float *target, plan_line_data_t *pl_data, float *position)
+{
+  // this simply moves to the target. Replace with your kinematics.
+  mc_line(target, pl_data);
+}
+
+/*
+  kinematics_pre_homing() is called before normal homing
+  You can use it to do special homing or just to set stuff up
+
+  cycle_mask is a bit mask of the axes being homed this time.
+*/
+bool kinematics_pre_homing(uint8_t cycle_mask))
+{
+  return false; // finish normal homing cycle
+}
+
+/*
+  kinematics_post_homing() is called at the end of normal homing
+*/
+void kinematics_post_homing()
+{
+}
+#endif
+
+#ifdef USE_FWD_KINEMATIC
+/*
+  The status command uses forward_kinematics() to convert
+  your motor positions to cartesian X,Y,Z... coordinates.
+
+  Convert the N_AXIS array of motor positions to cartesian in your code.
+*/
+void forward_kinematics(float *position)
+{
+  // position[X_AXIS] =
+  // position[Y_AXIS] =
+}
+#endif
+
+#ifdef USE_TOOL_CHANGE
+/*
+  user_tool_change() is called when tool change gcode is received,
+  to perform appropriate actions for your machine.
+*/
+void user_tool_change(uint8_t new_tool)
+{
+}
+#endif
+
+#if defined(MACRO_BUTTON_0_PIN) || defined(MACRO_BUTTON_1_PIN) || defined(MACRO_BUTTON_2_PIN)
+/*
+  options.  user_defined_macro() is called with the button number to
+  perform whatever actions you choose.
+*/
+void user_defined_macro(uint8_t index)
+{
+}
+#endif
+
+#ifdef USE_M30
+/*
+  user_m30() is called when an M30 gcode signals the end of a gcode file.
+*/
+void user_m30()
+{
+}
+#endif
+
+#ifdef USE_MACHINE_TRINAMIC_INIT
+/*
+  machine_triaminic_setup() replaces the normal setup of trinamic
+  drivers with your own code.  For example, you could setup StallGuard
+*/
+void machine_trinamic_setup()
+{
+}
+#endif
+
+// If you add any additional functions specific to your machine that
+// require calls from common code, guard their calls in the common code with
+// #ifdef USE_WHATEVER and add function prototypes (also guarded) to grbl.h

--- a/Grbl_Esp32/Custom/pick_place.cpp
+++ b/Grbl_Esp32/Custom/pick_place.cpp
@@ -51,8 +51,8 @@ enabled with USE_ defines in Machines/my_machine.h
 #ifdef USE_IO_EXPANDER
 
 PCF8574 expander[] = {
-  PCF8574(0x38),
-  PCF8574(0x39),
+  PCF8574(EXPANDER_0_I2C_ADDR),
+  PCF8574(EXPANDER_1_I2C_ADDR),
 };
 
 #define MAX_PIN 64

--- a/Grbl_Esp32/Custom/pick_place.cpp
+++ b/Grbl_Esp32/Custom/pick_place.cpp
@@ -1,5 +1,5 @@
 /*
-	custom_code_template.cpp (copy and use your machine name)
+	pick_place.cpp
 	Part of Grbl_ESP32
 
 	copyright (c) 2020 -	Bart Dring. This file was intended for use on the ESP32
@@ -86,6 +86,8 @@ special things your machine needs at startup.
 */
 void machine_init()
 {
+  expander[0].begin();
+  expander[1].begin();
 }
 #endif
 

--- a/Grbl_Esp32/Machines/pick_place.h
+++ b/Grbl_Esp32/Machines/pick_place.h
@@ -1,5 +1,5 @@
 /*
-    template.h
+    pick_place.h
     Part of Grbl_ESP32
 
     Template for a machine configuration file.
@@ -74,6 +74,8 @@
 
 #define SDA_PIN GPIO_NUM_21
 #define SCL_PIN GPIO_NUM_22
+
+#define USE_MACHINE_INIT
 
 // === Number of axes
 
@@ -272,7 +274,7 @@
 // USE_MACHINE_TRINAMIC_INIT enables the machine_triaminic_setup()
 // function that replaces the normal setup of Triaminic drivers.
 // It could, for, example, setup StallGuard or other special modes.
-#define USE_MACHINE_TRINAMIC_INIT
+// #define USE_MACHINE_TRINAMIC_INIT
 
 
 // === Grbl behavior options

--- a/Grbl_Esp32/Machines/pick_place.h
+++ b/Grbl_Esp32/Machines/pick_place.h
@@ -1,0 +1,283 @@
+/*
+    template.h
+    Part of Grbl_ESP32
+
+    Template for a machine configuration file.
+
+    2020    - Mitch Bradley
+
+    Grbl_ESP32 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Grbl is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// This contains a long list of things that might possibly be
+// configured.  Most machines - especially simple cartesian machines
+// that use stepper motors - will only need to define a few of the
+// options herein, often just the pin assignments.
+
+// Pin assignments depend on how the ESP32 is connected to
+// the external machine.  Typically the ESP32 module plugs into
+// an adapter board that wires specific ESP32 GPIO pins to
+// other connectors on the board, such as Pololu sockets for
+// stepper drivers or connectors for external drivers, limit
+// pins, spindle control, etc.  This file describes how those
+// GPIO pins are wired to those other connectors.
+
+// Some machines might choose to use an adapter board in a
+// non-standard way, for example a 3-axis board might have axes
+// labeled XYZ, but the machine might have only 2 axes one of which is
+// driven by two ganged motors.  In that case, you would need
+// a custom version of this file that assigns the pins differently
+// from the adapter board labels.
+
+// In addition to pin assignments, many other aspects of Grbl
+// can be configured, such as spindle speeds, special motor
+// types like servos and unipolars, homing order, default values
+// for $$ settings, etc.  A detailed list of such options is
+// given below.
+
+// Furthermore, it is possible to implement special complex
+// behavior in custom C++ code, for non-Cartesian machines,
+// unusual homing cycles, etc.  See the Special Features section
+// below for additional instructions.
+
+// === Machine Name
+// Change TEMPLATE to some name of your own choosing.  That name
+// will be shown in a Grbl startup message to identify your
+// configuration.
+
+#define MACHINE_NAME            "PICK_PLACE"
+
+// If your machine requires custom code as described below in
+// Special Features, you must copy Custom/custom_code_template.cpp
+// to a new name like Custom/my_custom_code.cpp, implement the
+// functions therein, and enable its use by defining:
+
+#define CUSTOM_CODE_FILENAME "Custom/pick_place.cpp"
+
+// Enables the use of I/O Expander versions of digitalWrite
+// and pinMode for USER_DIGITAL_PINs
+#define USE_IO_EXPANDER
+
+// Enables the driver code for the PCF8574 I2C I/O Expander
+#define USE_PCF8574
+
+#define SDA_PIN GPIO_NUM_21
+#define SCL_PIN GPIO_NUM_22
+
+// === Number of axes
+
+// You can set the number of axes that the machine supports
+// by defining N_AXIS.  If you do not define it, 3 will be
+// used.  The value must be at least 3, even if your machine
+// has fewer axes.
+#define N_AXIS 5
+
+
+// == Pin Assignments
+
+// Step and direction pins; these must be output-capable pins,
+// specifically ESP32 GPIO numbers 0..31
+#define X_STEP_PIN              GPIO_NUM_12
+#define X_DIRECTION_PIN         GPIO_NUM_26
+#define Y_STEP_PIN              GPIO_NUM_14
+#define Y_DIRECTION_PIN         GPIO_NUM_25
+#define Z_STEP_PIN              GPIO_NUM_2
+#define Z_DIRECTION_PIN         GPIO_NUM_4
+#define A_STEP_PIN              GPIO_NUM_27
+#define A_DIRECTION_PIN         GPIO_NUM_33
+#define B_STEP_PIN              GPIO_NUM_15
+#define B_DIRECTION_PIN         GPIO_NUM_32
+
+#define USER_DIGITAL_PIN_0 (64 + 5)
+#define USER_DIGITAL_PIN_1 (64 + 6)
+#define USER_DIGITAL_PIN_2 (64 + 7)
+#define USER_DIGITAL_PIN_3 (64*1 + 0)
+
+// The 1 bits in LIMIT_MASK set the axes that have limit switches
+// For example, if the Y axis has no limit switches but the
+// X, Z, A and B axes do, the LIMIT_MASK value would be B11101
+#define LIMIT_MASK              B1111
+
+#define X_LIMIT_PIN             GPIO_NUM_34
+#define Y_LIMIT_PIN             GPIO_NUM_35
+#define Z_LIMIT_PIN             GPIO_NUM_36
+#define A_LIMIT_PIN             GPIO_NUM_39
+
+// Common enable for all steppers.  If it is okay to leave
+// your drivers enabled at all times, you can leave
+// STEPPERS_DISABLE_PIN undefined and use the pin for something else.
+// #define STEPPERS_DISABLE_PIN    GPIO_NUM_13
+
+// Pins for controlling various aspects of the machine.  If your
+// machine does not support one of these features, you can leave
+// the corresponding pin undefined.
+
+// #define SPINDLE_PWM_PIN         GPIO_NUM_2   // labeled SpinPWM
+// #define SPINDLE_ENABLE_PIN      GPIO_NUM_22  // labeled SpinEnbl
+// #define COOLANT_MIST_PIN        GPIO_NUM_21  // labeled Mist
+// #define COOLANT_FLOOD_PIN       GPIO_NUM_25  // labeled Flood
+// #define PROBE_PIN               GPIO_NUM_32  // labeled Probe
+
+// Input pins for various functions.  If the corresponding pin is not defined,
+// the function will not be available.
+
+// CONTROL_SAFETY_DOOR_PIN shuts off the machine when a door is opened
+// or some other unsafe condition exists.
+// #define CONTROL_SAFETY_DOOR_PIN GPIO_NUM_35  // labeled Door,  needs external pullup
+
+// RESET, FEED_HOLD, and CYCLE_START can control GCode execution at
+// the push of a button.
+
+// #define CONTROL_RESET_PIN       GPIO_NUM_34  // labeled Reset, needs external pullup
+// #define CONTROL_FEED_HOLD_PIN   GPIO_NUM_36  // labeled Hold,  needs external pullup
+// #define CONTROL_CYCLE_START_PIN GPIO_NUM_39  // labeled Start, needs external pullup
+
+// === Ganging
+// If you need to use two motors on one axis, you can "gang" the motors by
+// defining a second pin to control the other motor on the axis.  For example:
+
+// #define Y2_STEP_PIN             GPIO_NUM_27  /* labeled Z */
+// #define Y2_DIRECTION_PIN        GPIO_NUM_33  /* labeled Z */
+
+// === Servos
+// To use a servo motor on an axis, do not define step and direction
+// pins for that axis, but instead include a block like this:
+// #define USE_SERVO_AXES
+
+// #define SERVO_Z_PIN             GPIO_NUM_22
+// #define SERVO_Z_CHANNEL_NUM     6
+// #define SERVO_Z_RANGE_MIN       0.0
+// #define SERVO_Z_RANGE_MAX       5.0
+// #define SERVO_Z_HOMING_TYPE     SERVO_HOMING_TARGET // during homing it will instantly move to a target value
+// #define SERVO_Z_HOME_POS        SERVO_Z_RANGE_MAX // move to max during homing
+// #define SERVO_Z_MPOS            false           // will not use mpos, uses work coordinates
+
+// === Homing cycles
+// The default homing order is Z first (HOMING_CYCLE_0),
+// then X (HOMING_CYCLE_1), and finally Y (HOMING_CYCLE_2)
+// For machines that need different homing order, you can
+// undefine HOMING_CYCLE_n and redefine it accordingly.
+// For example, the following would first home X and Y
+// simultaneously, then A and B simultaneously, and Z
+// not at all.
+
+// #undef HOMING_CYCLE_0
+// #define HOMING_CYCLE_0 ((1<<X_AXIS)|(1<<Y_AXIS))
+
+// #undef HOMING_CYCLE_1
+// #define HOMING_CYCLE_1 ((1<<A_AXIS)|(1<<B_AXIS))
+
+// #undef HOMING_CYCLE_2
+// #endif
+
+// === Default settings
+// Grbl has many run-time settings that the user can changed by
+// commands like $110=2000 .  Their values are stored in EEPROM
+// so they persist after the controller has been powered down.
+// Those settings have default values that are used if the user
+// has not altered them, or if the settings are explicitly reset
+// to the default values wth $RST=$.
+//
+// The default values are established in defaults.h, but you
+// can override any one of them by definining it here, for example:
+
+//#define DEFAULT_INVERT_LIMIT_PINS 1
+//#define DEFAULT_REPORT_INCHES 1
+
+// === Control Pins
+
+// The control pins with names that begin with CONTROL_ are
+// ignored by default, to avoid noise problems.  To make them
+// work, you must undefine IGNORE_CONTROL_PINS
+// #undef IGNORE_CONTROL_PINS
+
+// If some of the control pin switches are normally closed
+// (the default is normally open), you can invert some of them
+// with INVERT_CONTROL_PIN_MASK.  The bits in the mask are
+// Cycle Start, Feed Hold, Reset, Safety Door.  To use a
+// normally open switch on Reset, you would say
+// #define INVERT_CONTROL_PIN_MASK B1101
+
+// If your control pins do not have adequate hardware signal
+// conditioning, you can define these to use software to
+// reduce false triggering.
+// #define ENABLE_CONTROL_SW_DEBOUNCE // Default disabled. Uncomment to enable.
+// #define CONTROL_SW_DEBOUNCE_PERIOD 32 // in milliseconds default 32 microseconds
+
+
+// Grbl_ESP32 use the ESP32's special RMT (IR remote control) hardware
+// engine to achieve more precise high step rates than can be done
+// in software.  That feature is enabled by default, but there are
+// some machines that might not want to use it, such as machines that
+// do not use ordinary stepper motors.  To turn it off, do this:
+// #undef USE_RMT_STEPS
+
+// === Special Features
+// Grbl_ESP32 can support non-Cartesian machines and some other
+// scenarios that cannot be handled by choosing from a set of
+// predefined selections.  Instead they require machine-specific
+// C++ code functions.  There are callouts in the core code for
+// such code, guarded by ifdefs that enable calling the individual
+// functions.  custom_code_template.cpp describes the functions
+// that you can implement.  The ifdef guards are described below:
+//
+// USE_CUSTOM_HOMING enables the user_defined_homing() function
+// that can implement an arbitrary homing sequence.
+// #define USE_CUSTOM_HOMING
+
+// USE_KINEMATICS enables the functions inverse_kinematics(),
+// kinematics_pre_homing(), and kinematics_post_homing(),
+// so non-Cartesian machines can be implemented.
+// #define USE_KINEMATICS
+
+// USE_FWD_KINEMATIC enables the forward_kinematics() function
+// that converts motor positions in non-Cartesian coordinate
+// systems back to Cartesian form, for status reports.
+//#define USE_FWD_KINEMATIC
+
+// USE_TOOL_CHANGE enables the user_tool_change() function
+// that implements custom tool change procedures.
+// #define USE_TOOL_CHANGE
+
+// Any one of MACRO_BUTTON_0_PIN, MACRO_BUTTON_1_PIN, and MACRO_BUTTON_2_PIN
+// enables the user_defined_macro(number) function which
+// implements custom behavior at the press of a button
+// #define MACRO_BUTTON_0_PIN
+
+// USE_M30 enables the user_m30() function which implements
+// custom behavior when a GCode programs stops at the end
+// #define USE_M30
+
+// USE_TRIAMINIC enables a suite of functions that are defined
+// in grbl_triaminic.cpp, allowing the use of Triaminic stepper
+// drivers that require software configuration at startup.
+// There are several options that control the details of such
+// drivers; inspect the code in grbl_triaminic.cpp to see them.
+// #define USE_TRIAMINIC
+// #define X_TRIAMINIC
+// #define X_DRIVER_TMC2209
+// #define TRIAMINIC_DAISY_CHAIN
+
+// USE_MACHINE_TRINAMIC_INIT enables the machine_triaminic_setup()
+// function that replaces the normal setup of Triaminic drivers.
+// It could, for, example, setup StallGuard or other special modes.
+#define USE_MACHINE_TRINAMIC_INIT
+
+
+// === Grbl behavior options
+// There are quite a few options that control aspects of Grbl that
+// are not specific to particular machines.  They are listed and
+// described in config.h after it includes the file machine.h.
+// Normally you would not need to change them, but if you do,
+// it will be necessary to make the change in config.h

--- a/Grbl_Esp32/Machines/pick_place.h
+++ b/Grbl_Esp32/Machines/pick_place.h
@@ -77,6 +77,9 @@
 
 #define USE_MACHINE_INIT
 
+#define EXPANDER_0_I2C_ADDR 0x38
+#define EXPANDER_1_I2C_ADDR 0x39
+
 // === Number of axes
 
 // You can set the number of axes that the machine supports
@@ -101,10 +104,10 @@
 #define B_STEP_PIN              GPIO_NUM_15
 #define B_DIRECTION_PIN         GPIO_NUM_32
 
-#define USER_DIGITAL_PIN_0 (64 + 5)
-#define USER_DIGITAL_PIN_1 (64 + 6)
-#define USER_DIGITAL_PIN_2 (64 + 7)
-#define USER_DIGITAL_PIN_3 (64*1 + 0)
+#define USER_DIGITAL_PIN_1 (64 + 5)
+#define USER_DIGITAL_PIN_2 (64 + 6)
+#define USER_DIGITAL_PIN_3 (64 + 7)
+#define USER_DIGITAL_PIN_4 (64*1 + 0)
 
 // The 1 bits in LIMIT_MASK set the axes that have limit switches
 // For example, if the Y axis has no limit switches but the

--- a/Grbl_Esp32/config.h
+++ b/Grbl_Esp32/config.h
@@ -103,6 +103,14 @@ Some features should not be changed. See notes below.
     #define LIMIT_MASK B0
 #endif
 
+#ifdef USE_IO_EXPANDER
+#define EXPANDER_PIN_MODE expanderPinMode
+#define EXPANDER_DIGITAL_WRITE expanderDigitalWrite
+#else
+#define EXPANDER_PIN_MODE PinMode
+#define EXPANDER_DIGITAL_WRITE digitalWrite
+#endif
+
 #define VERBOSE_HELP // Currently this doesn't do anything
 #define GRBL_MSG_LEVEL MSG_LEVEL_INFO // what level of [MSG:....] do you want to see 0=all off
 

--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -79,6 +79,14 @@
 
 #include "solenoid_pen.h"
 
+#ifdef USE_PCF8574
+    #include <Wire.h>
+#endif
+
+#ifdef USE_IO_EXPANDER
+    #include "io_expander.h"
+#endif
+
 #ifdef USE_SERVO_AXES
     #include "servo_axis.h"
 #endif

--- a/Grbl_Esp32/io_expander.h
+++ b/Grbl_Esp32/io_expander.h
@@ -1,0 +1,32 @@
+/*
+ io_expander.h
+  Part of Grbl_ESP32
+
+	copyright (c) 2019 -	Bart Dring. This file was intended for use on the ESP32
+					CPU. Do not use this with Grbl for atMega328P
+
+  Grbl is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Grbl is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
+
+  IO Expander definitions
+
+  These definitions let you use an I/O expander, for example
+  one connected via I2C, for extra low-speed digital outputs.
+*/
+#ifndef io_expander_h
+#define io_expander_h
+
+void expanderPinMode(uint8_t pin, uint8_t mode);
+void expanderDigitalWrite(uint8_t pin, uint8_t value);
+
+#endif

--- a/Grbl_Esp32/machine.h
+++ b/Grbl_Esp32/machine.h
@@ -8,7 +8,8 @@
 
 // !!! For initial testing, start with test_drive.h which disables
 // all I/O pins
-#include "Machines/test_drive.h"
+// #include "Machines/test_drive.h"
+#include "Machines/pick_place.h"
 
 // !!! For actual use, change the line above to select a board
 // from Machines/, for example:

--- a/Grbl_Esp32/system.cpp
+++ b/Grbl_Esp32/system.cpp
@@ -80,19 +80,19 @@ void system_ini() { // Renamed from system_init() due to conflict with esp32 fil
 #endif
     // Setup USER_DIGITAL_PINs controlled by M62 and M63
 #ifdef USER_DIGITAL_PIN_1
-    pinMode(USER_DIGITAL_PIN_1, OUTPUT);
+    EXPANDER_PIN_MODE(USER_DIGITAL_PIN_1, OUTPUT);
     sys_io_control(1 << 1, false); // turn off
 #endif
 #ifdef USER_DIGITAL_PIN_2
-    pinMode(USER_DIGITAL_PIN_2, OUTPUT);
+    EXPANDER_PIN_MODE(USER_DIGITAL_PIN_2, OUTPUT);
     sys_io_control(1 << 2, false); // turn off
 #endif
 #ifdef USER_DIGITAL_PIN_3
-    pinMode(USER_DIGITAL_PIN_3, OUTPUT);
+    EXPANDER_PIN_MODE(USER_DIGITAL_PIN_3, OUTPUT);
     sys_io_control(1 << 3, false); // turn off
 #endif
 #ifdef USER_DIGITAL_PIN_4
-    pinMode(USER_DIGITAL_PIN_4, OUTPUT);
+    EXPANDER_PIN_MODE(USER_DIGITAL_PIN_4, OUTPUT);
     sys_io_control(1 << 4, false); // turn off
 #endif
 }
@@ -553,25 +553,25 @@ void sys_io_control(uint8_t io_num_mask, bool turnOn) {
     protocol_buffer_synchronize();
 #ifdef USER_DIGITAL_PIN_1
     if (io_num_mask & 1 << 1) {
-        digitalWrite(USER_DIGITAL_PIN_1, turnOn);
+        EXPANDER_DIGITAL_WRITE(USER_DIGITAL_PIN_1, turnOn);
         return;
     }
 #endif
 #ifdef USER_DIGITAL_PIN_2
     if (io_num_mask & 1 << 2) {
-        digitalWrite(USER_DIGITAL_PIN_2, turnOn);
+        EXPANDER_DIGITAL_WRITE(USER_DIGITAL_PIN_2, turnOn);
         return;
     }
 #endif
 #ifdef USER_DIGITAL_PIN_3
     if (io_num_mask & 1 << 3) {
-        digitalWrite(USER_DIGITAL_PIN_3, turnOn);
+        EXPANDER_DIGITAL_WRITE(USER_DIGITAL_PIN_3, turnOn);
         return;
     }
 #endif
 #ifdef USER_DIGITAL_PIN_4
     if (io_num_mask & 1 << 4) {
-        digitalWrite(USER_DIGITAL_PIN_4, turnOn);
+        EXPANDER_DIGITAL_WRITE(USER_DIGITAL_PIN_4, turnOn);
         return;
     }
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ lib_deps_builtin =
 
 [env:nodemcu-32s]
 lib_deps = TMCStepper
+        PCF8574
 platform = espressif32
 board = nodemcu-32s
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,3 +31,4 @@ board_build.partitions = min_spiffs.csv
 monitor_speed = 115200
 build_flags = -DCORE_DEBUG_LEVEL=0 -Wno-unused-variable -Wno-unused-function
 src_filter = +<*.h> +<*.s> +<*.S> +<*.cpp> +<*.c> +<*.ino> +<src/> -<.git/> -<data/> -<test/> -<tests/> -<Custom/>
+monitor_flags = --echo


### PR DESCRIPTION
This PR is not intended for merging, rather it is a proof of concept and a basis for discussion.

**Scope**
It lets you use one or more I2C I/O Expanders - in this case PCF8574 - to provide supplemental low-speed output via M62 and M63.  USER_DIGITAL_PIN numbers are extended so that GPIO numbers >= 64 refer to expander pins.  The expanded access functions apply only to the M62 and M63 cases, so there is no speed impact on high-speed I/O.

**Discussion**
I tried to implement it by overriding the weak definitions of digitalWrite and pinMode, but making that work required a change in esp32_hal_gpio.h to expose the otherwise-hidden functions __digitalWrite() and __pinMode() for the fallback code.  Modifying system functions seemed like a bad idea so I introduced macros EXPANDER_DIGITAL_WRITE and EXPANDER_PIN_MODE that resolve to digitalWrite and pinMode in the default case, and to expanderDigitalWrite and expanderPinMode if I/O Expander support is present.

Except for the plumbing for those macros and a bit of #include wrangling that is necessary to make the build system do the right thing, the main changes are buried in a new file Custom/pick_place.cpp .
