### PR TITLE
Suppress Intellisense problem reports

### DIFF
--- a/Grbl_Esp32/Spindles/BESCSpindle.cpp
+++ b/Grbl_Esp32/Spindles/BESCSpindle.cpp
@@ -30,6 +30,7 @@
     BESC_MAX_PULSE_SECS is typically 2ms (0.002 sec) or more
 
 */
+#include "SpindleClass.h"
 
 // don't change these
 #define BESC_PWM_FREQ           50.0f // Hz

--- a/Grbl_Esp32/Spindles/DacSpindle.cpp
+++ b/Grbl_Esp32/Spindles/DacSpindle.cpp
@@ -21,6 +21,7 @@
     along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
 */
+#include "SpindleClass.h"
 
 // ======================================== DacSpindle ======================================
 void DacSpindle :: init() {

--- a/Grbl_Esp32/Spindles/HuanyangSpindle.cpp
+++ b/Grbl_Esp32/Spindles/HuanyangSpindle.cpp
@@ -47,6 +47,8 @@
         What happens if the VFD does not respond
         Add periodic pinging of VFD in run mode to see if it is still at correct RPM
 */
+#include "SpindleClass.h"
+
 #include "driver/uart.h"
 
 #define HUANYANG_UART_PORT      UART_NUM_2      // hard coded for this port right now

--- a/Grbl_Esp32/Spindles/Laser.cpp
+++ b/Grbl_Esp32/Spindles/Laser.cpp
@@ -19,6 +19,7 @@
     along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
 */
+#include "SpindleClass.h"
 
 // ===================================== Laser ==============================================
 

--- a/Grbl_Esp32/Spindles/NullSpindle.cpp
+++ b/Grbl_Esp32/Spindles/NullSpindle.cpp
@@ -19,9 +19,11 @@
     along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
 */
+#include "SpindleClass.h"
 
 // ======================= NullSpindle ==============================
 // NullSpindle is just bunch of do nothing (ignore) methods to be used when you don't want a spindle
+
 void NullSpindle :: init() {
     is_reversable = false;
     config_message();

--- a/Grbl_Esp32/Spindles/PWMSpindle.cpp
+++ b/Grbl_Esp32/Spindles/PWMSpindle.cpp
@@ -19,6 +19,7 @@
     along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
 */
+#include "SpindleClass.h"
 
 // ======================= PWMSpindle ==============================
 /*

--- a/Grbl_Esp32/Spindles/RelaySpindle.cpp
+++ b/Grbl_Esp32/Spindles/RelaySpindle.cpp
@@ -19,6 +19,7 @@
     along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
 */
+#include "SpindleClass.h"
 
 // ========================= RelaySpindle ==================================
 /*


### PR DESCRIPTION
The .cpp files for spindles are included into
one large compilation unit that shares a .h
file, so it should not be necessary to
#include SpindleClass.h in each one, but
Intellisense doesn't know that so it issues
numerous problem reports.  The solution
is to #include SpindleClass.h in each
Spindle*.cpp file, letting the header guard
prevent multiple inclusion during compilation.