### PR TITLE
Partial match of settings names

### DIFF
--- a/Grbl_Esp32/ProcessSettings.cpp
+++ b/Grbl_Esp32/ProcessSettings.cpp
@@ -480,7 +480,6 @@ err_t do_command_or_setting(const char *key, char *value, ESPResponseStream* out
             auto lcTest = String(s->getName());
             lcTest.toLowerCase();
 
-            //            if (strstr(lcTest.c_str(), lcKey.c_str()) != NULL) {
             if (lcTest.indexOf(lcKey) >= 0) {
                 grbl_sendf(out->client(), "$%s=%s\n", s->getName(), s->getStringValue());
                 retval = STATUS_OK;


### PR DESCRIPTION
If you say  $st  and that does not exactly match a setting, it will show all the settings whose names contain the substring "st".  You can also prefix the match string with *, as in $*x , which is useful to force a setting display when there is already an exact match, for example with the $X command.