### PR TITLE
Fix compile problems with different ENABLE_s

### DIFF
--- a/Grbl_Esp32/espresponse.h
+++ b/Grbl_Esp32/espresponse.h
@@ -41,8 +41,8 @@ class ESPResponseStream {
     ESPResponseStream();
   private:
     uint8_t _client;
-#if defined (ENABLE_HTTP) && defined(ENABLE_WIFI)
     bool _header_sent;
+#if defined (ENABLE_HTTP) && defined(ENABLE_WIFI)
     WebServer* _webserver;
     String _buffer;
 #endif


### PR DESCRIPTION
Some WebUI commands were present even when the
relevant ENABLE_ was not defined,  This corrects
that and make the presence/absense of the various
commands correspond to the old code with different
combinations of web-related enables in config.h

To make things easier to find, the order of the
web command functions in the file now corresponds
with the listed order of the command names.