### PR TITLE
Fixed the problem of combining I2S and TMC2130 SPI

### DIFF
--- a/Grbl_Esp32/Grbl_Esp32.ino
+++ b/Grbl_Esp32/Grbl_Esp32.ino
@@ -42,6 +42,22 @@ Spindle *spindle;
 
 
 void setup() {
+#ifdef USE_I2S_OUT
+#ifndef I2S_OUT_INITIAL_VALUE
+#define I2S_OUT_INITIAL_VALUE 0
+#endif
+    // The I2S I/O expander must be initialized before it can access the enhanced GPIO port
+    i2s_out_init_t param = {
+        .ws_pin = I2S_OUT_WS,
+        .bck_pin = I2S_OUT_BCK,
+        .data_pin = I2S_OUT_DATA,
+        .pulse_func = NULL,
+        .pulse_period = F_TIMERS / F_STEPPER_TIMER, // default
+        .init_val = I2S_OUT_INITIAL_VALUE,
+    };
+    i2s_out_init(param);
+    delay(I2S_OUT_DELAY_MS);
+#endif
     WiFi.persistent(false);
     WiFi.disconnect(true);
     WiFi.enableSTA(false);
@@ -58,21 +74,6 @@ void setup() {
     #define MACHINE_STRING MACHINE_NAME
   #endif
     report_machine_type(CLIENT_SERIAL);
-#endif
-#ifdef USE_I2S_OUT
-#ifndef I2S_OUT_INITIAL_VALUE
-#define I2S_OUT_INITIAL_VALUE 0
-#endif
-    // The I2S I/O expander must be initialized before it can access the enhanced GPIO port
-    i2s_out_init_t param = {
-        .ws_pin = I2S_OUT_WS,
-        .bck_pin = I2S_OUT_BCK,
-        .data_pin = I2S_OUT_DATA,
-        .pulse_func = NULL,
-        .pulse_period = F_TIMERS / F_STEPPER_TIMER, // default
-        .init_val = I2S_OUT_INITIAL_VALUE,
-    };
-    i2s_out_init(param);
 #endif
     settings_init(); // Load Grbl settings from EEPROM
     stepper_init();  // Configure stepper pins and interrupt timers

--- a/Grbl_Esp32/Machines/i2s_out_xyzabc_tmc.h
+++ b/Grbl_Esp32/Machines/i2s_out_xyzabc_tmc.h
@@ -110,5 +110,3 @@
 
 // === Default settings
 #define DEFAULT_STEP_PULSE_MICROSECONDS I2S_OUT_USEC_PER_PULSE
-
-#define I2S_OUT_INITIAL_VALUE (bit(3) | bit(6) | bit(11) | bit(14) | bit(19) | bit(22))

--- a/Grbl_Esp32/Motors/MotorClass.cpp
+++ b/Grbl_Esp32/Motors/MotorClass.cpp
@@ -364,30 +364,29 @@ void motors_set_direction_pins(uint8_t onMask) {
 }
 
 // for testing
-/*
-
+#ifndef USE_TRINAMIC
 // returns the next spi index. We cannot preassign to axes because ganged (X2 type axes) might
 // need to be inserted into the order of axes.
 uint8_t get_next_trinamic_driver_index() {
+#ifdef TRINAMIC_DAISY_CHAIN
     static uint8_t index = 1; // they start at 1
-#ifndef TRINAMIC_DAISY_CHAIN
-    return -1;
-#else
     return index++;
+#else
+    return -1;
 #endif
 }
-
 #ifdef USE_I2S_OUT
 //
 // Override default function and insert a short delay
 //
 void TMC2130Stepper::switchCSpin(bool state) {
     digitalWrite(_pinCS, state);
-    //grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "CS (%d)", state);
     delay(I2S_OUT_DELAY_MS);
 }
 #endif
-*/
+
+#endif
+
 // ============================== Class Methods ================================================
 
 Motor :: Motor() {

--- a/Grbl_Esp32/config.h
+++ b/Grbl_Esp32/config.h
@@ -114,7 +114,7 @@ Some features should not be changed. See notes below.
 //CONFIGURE_EYECATCH_BEGIN (DO NOT MODIFY THIS LINE)
 #define ENABLE_BLUETOOTH // enable bluetooth
 
-//#define ENABLE_SD_CARD // enable use of SD Card to run jobs
+#define ENABLE_SD_CARD // enable use of SD Card to run jobs
 
 #define ENABLE_WIFI //enable wifi
 
@@ -136,7 +136,7 @@ Some features should not be changed. See notes below.
 
 #define ENABLE_CAPTIVE_PORTAL
 //#define ENABLE_AUTHENTICATION
-//CONFIGURE_EYECATCH_END (DO NOT MODIFY  THIS LINE)
+//CONFIGURE_EYECATCH_END (DO NOT MODIFY THIS LINE)
 #define NAMESPACE "GRBL"
 
 #ifdef ENABLE_AUTHENTICATION

--- a/Grbl_Esp32/grbl_trinamic.cpp
+++ b/Grbl_Esp32/grbl_trinamic.cpp
@@ -190,50 +190,62 @@ void Trinamic_Init() {
 #ifdef X_DRIVER_TMC2130
     pinMode(X_CS_PIN, OUTPUT);
     digitalWrite(X_CS_PIN, HIGH);
+    TRINAMIC_X.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef X2_DRIVER_TMC2130
     pinMode(X2_CS_PIN, OUTPUT);
     digitalWrite(X2_CS_PIN, HIGH);
+    TRINAMIC_X2.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef Y_DRIVER_TMC2130
     pinMode(Y_CS_PIN, OUTPUT);
     digitalWrite(Y_CS_PIN, HIGH);
+    TRINAMIC_Y.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef Y2_DRIVER_TMC2130
     pinMode(Y2_CS_PIN, OUTPUT);
     digitalWrite(Y2_CS_PIN, HIGH);
+    TRINAMIC_Y2.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef Z_DRIVER_TMC2130
     pinMode(Z_CS_PIN, OUTPUT);
     digitalWrite(Z_CS_PIN, HIGH);
+    TRINAMIC_Z.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef Z2_DRIVER_TMC2130
     pinMode(Z2_CS_PIN, OUTPUT);
     digitalWrite(Z2_CS_PIN, HIGH);
+    TRINAMIC_Z2.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef A_DRIVER_TMC2130
     pinMode(A_CS_PIN, OUTPUT);
     digitalWrite(A_CS_PIN, HIGH);
+    TRINAMIC_A.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef A2_DRIVER_TMC2130
     pinMode(A2_CS_PIN, OUTPUT);
     digitalWrite(A2_CS_PIN, HIGH);
+    TRINAMIC_A2.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef B_DRIVER_TMC2130
     pinMode(B_CS_PIN, OUTPUT);
     digitalWrite(B_CS_PIN, HIGH);
+    TRINAMIC_B.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef B2_DRIVER_TMC2130
     pinMode(B2_CS_PIN, OUTPUT);
     digitalWrite(B2_CS_PIN, HIGH);
+    TRINAMIC_B2.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef C_DRIVER_TMC2130
     pinMode(C_CS_PIN, OUTPUT);
     digitalWrite(C_CS_PIN, HIGH);
+    TRINAMIC_C.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 #ifdef C2_DRIVER_TMC2130
     pinMode(C2_CS_PIN, OUTPUT);
     digitalWrite(C2_CS_PIN, HIGH);
+    TRINAMIC_C2.setSPISpeed(TRINAMIC_SPI_FREQ);
 #endif
 
     SPI.begin();

--- a/Grbl_Esp32/grbl_trinamic.h
+++ b/Grbl_Esp32/grbl_trinamic.h
@@ -29,6 +29,8 @@
 #define TMC2130_RSENSE_DEFAULT  0.11f
 #define TMC5160_RSENSE_DEFAULT  0.075f
 
+#define TRINAMIC_SPI_FREQ 100000
+
 #ifdef USE_TRINAMIC
     #include <TMCStepper.h> // https://github.com/teemuatlut/TMCStepper
     void Trinamic_Init();


### PR DESCRIPTION
Fixed a problem in which setting via SPI failed when the I2S I/O expander was used to control the CS pins of the TMC2130.
- Reduce SPI clock to 100KHz
- Moved the start of I2S out execution to just after setup().

Before fix:
```
[MSG:Grbl_ESP32 Ver 1.2a Date 20200605]
[MSG:Compiled with ESP32 SDK:v3.2.3-14-gd3e562907]
[MSG:Using machine:ESP32 SPI 6 Axis Driver Board (Trinamic)]
[MSG:Axis count 6]
[MSG:I2S Steps]
[MSG:TMCStepper Init using Library Ver 0x000602]
[MSG:X Trinamic driver test failed. Check motor power]
[MSG:Y Trinamic driver test failed. Check connection]
[MSG:Z Trinamic driver test failed. Check connection]
[MSG:A Trinamic driver test passed]
[MSG:B Trinamic driver test passed]
[MSG:C Trinamic driver test passed]
[MSG:Init Motors]
[MSG:X Axis standard stepper motor Step:I2SO_2 Dir:I2SO_1 Disable:I2SO_0]
[MSG:Y Axis standard stepper motor Step:I2SO_5 Dir:I2SO_4 Disable:I2SO_7]
[MSG:Z Axis standard stepper motor Step:I2SO_10 Dir:I2SO_9 Disable:I2SO_8]
[MSG:A Axis standard stepper motor Step:I2SO_13 Dir:I2SO_12 Disable:I2SO_15]
[MSG:B Axis standard stepper motor Step:I2SO_18 Dir:I2SO_17 Disable:I2SO_16]
[MSG:C Axis standard stepper motor Step:I2SO_21 Dir:I2SO_20 Disable:I2SO_23]
[MSG:PWM spindle Output:GPIO_26, Enbl:GPIO_4, Dir:GPIO_16, Freq:5000Hz, Res:13bits]
[MSG:Local access point GRBL_ESP started, 192.168.0.1]
[MSG:Captive Portal Started]
[MSG:HTTP Started]
[MSG:TELNET Started 23]
Grbl 1.2a ['$' for help]
```

After fix:
```
[MSG:Grbl_ESP32 Ver 1.2a Date 20200605]
[MSG:Compiled with ESP32 SDK:v3.2.3-14-gd3e562907]
[MSG:Using machine:ESP32 SPI 6 Axis Driver Board (Trinamic)]
[MSG:Axis count 6]
[MSG:I2S Steps]
[MSG:TMCStepper Init using Library Ver 0x000602]
[MSG:X Trinamic driver test passed]
[MSG:Y Trinamic driver test passed]
[MSG:Z Trinamic driver test passed]
[MSG:A Trinamic driver test passed]
[MSG:B Trinamic driver test passed]
[MSG:C Trinamic driver test passed]
[MSG:Init Motors]
[MSG:X Axis standard stepper motor Step:I2SO_2 Dir:I2SO_1 Disable:I2SO_0]
[MSG:Y Axis standard stepper motor Step:I2SO_5 Dir:I2SO_4 Disable:I2SO_7]
[MSG:Z Axis standard stepper motor Step:I2SO_10 Dir:I2SO_9 Disable:I2SO_8]
[MSG:A Axis standard stepper motor Step:I2SO_13 Dir:I2SO_12 Disable:I2SO_15]
[MSG:B Axis standard stepper motor Step:I2SO_18 Dir:I2SO_17 Disable:I2SO_16]
[MSG:C Axis standard stepper motor Step:I2SO_21 Dir:I2SO_20 Disable:I2SO_23]
[MSG:PWM spindle Output:GPIO_26, Enbl:GPIO_4, Dir:GPIO_16, Freq:5000Hz, Res:13bits]
[MSG:Local access point GRBL_ESP started, 192.168.0.1]
[MSG:Captive Portal Started]
[MSG:HTTP Started]
[MSG:TELNET Started 23]
Grbl 1.2a ['$' for help]
```