### PR TITLE
Reduce delay in I2S real-time mode

### DIFF
--- a/Grbl_Esp32/Motors/MotorClass.cpp
+++ b/Grbl_Esp32/Motors/MotorClass.cpp
@@ -442,7 +442,11 @@ void readSgTask(void* pvParameters) {
 //
 void TMC2130Stepper::switchCSpin(bool state) {
     digitalWrite(_pinCS, state);
+#ifdef USE_I2S_OUT_STREAM
     delay(I2S_OUT_DELAY_MS);
+#else
+    ets_delay_us(I2S_OUT_USEC_PER_PULSE);
+#endif
 }
 #endif
 


### PR DESCRIPTION
In I2S real-time mode, the delay time for applying changes can be reduced.

To test the effects, please comment out
#define USE_I2S_OUT_STREAM
in "i2s_out_xyzabc_trinamic.h".