### PR TITLE
ESP32 Exception decoder

### DIFF
--- a/debug.ini
+++ b/debug.ini
@@ -11,9 +11,6 @@ monitor_port = COM3
 ; Linux
 ;upload_port = /dev/ttyUSB*
 ;monitor_port = /dev/ttyUSB*
-monitor_flags =
-	--eol=CR
-	--echo
 build_flags =
     ${common.build_flags}
 	-DMACHINE_FILENAME=test_drive.h 

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,7 @@ monitor_speed = 115200
 monitor_flags =
 	--eol=CRLF
 	--echo
-        --filter=esp32_exception_decoder
+	--filter=esp32_exception_decoder
 board_build.f_cpu = 240000000L
 ; set frequency to 80MHz
 board_build.f_flash = 80000000L

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,10 @@ framework = arduino
 upload_speed = 921600
 board_build.partitions = min_spiffs.csv
 monitor_speed = 115200
+monitor_flags =
+	--eol=CRLF
+	--echo
+        --filter=esp32_exception_decoder
 board_build.f_cpu = 240000000L
 ; set frequency to 80MHz
 board_build.f_flash = 80000000L


### PR DESCRIPTION
Requires platformio platform espressif32 version >= 1.12.4