### PR TITLE
Sensor less homing with I2S OUT

### DIFF
--- a/Grbl_Esp32/SettingsDefinitions.cpp
+++ b/Grbl_Esp32/SettingsDefinitions.cpp
@@ -231,7 +231,7 @@ void make_settings() {
     c_axis_settings = axis_settings[C_AXIS];
     for (axis = N_AXIS - 1; axis >= 0; axis--) {
         def = &axis_defaults[axis];
-        auto setting = new IntSetting(EXTENDED, makeGrblName(axis, 170), makename(def->name, "StallGuard"), def->stallguard, 0, 100, checkStallguard);
+        auto setting = new IntSetting(EXTENDED, makeGrblName(axis, 170), makename(def->name, "StallGuard"), def->stallguard, -64, 63, checkStallguard);
         setting->setAxis(axis);
         axis_settings[axis]->stallguard = setting;
     }

--- a/Grbl_Esp32/defaults.h
+++ b/Grbl_Esp32/defaults.h
@@ -293,22 +293,22 @@
     // ========== Motor hold current (SPI Drivers ) =============
 
     #ifndef  DEFAULT_X_HOLD_CURRENT
-        #define DEFAULT_X_HOLD_CURRENT 50 // $150 percent of run current (extended set)
+        #define DEFAULT_X_HOLD_CURRENT 0.125 // $150 current in amps (extended set)
     #endif
     #ifndef  DEFAULT_Y_HOLD_CURRENT
-        #define DEFAULT_Y_HOLD_CURRENT 50 // $151 percent of run current (extended set)
+        #define DEFAULT_Y_HOLD_CURRENT 0.125 // $151 current in amps (extended set)
     #endif
     #ifndef  DEFAULT_Z_HOLD_CURRENT
-        #define DEFAULT_Z_HOLD_CURRENT 50 // $152 percent of run current (extended set)
+        #define DEFAULT_Z_HOLD_CURRENT 0.125 // $152 current in amps (extended set)
     #endif
     #ifndef  DEFAULT_A_HOLD_CURRENT
-        #define DEFAULT_A_HOLD_CURRENT 50 // $153 percent of run current (extended set)
+        #define DEFAULT_A_HOLD_CURRENT 0.125 // $153 current in amps (extended set)
     #endif
     #ifndef  DEFAULT_B_HOLD_CURRENT
-        #define DEFAULT_B_HOLD_CURRENT 50 // $154 percent of run current (extended set)
+        #define DEFAULT_B_HOLD_CURRENT 0.125 // $154 current in amps (extended set)
     #endif
     #ifndef  DEFAULT_C_HOLD_CURRENT
-        #define DEFAULT_C_HOLD_CURRENT 50 // $154 percent of run current (extended set)
+        #define DEFAULT_C_HOLD_CURRENT 0.125 // $154 current in amps (extended set)
     #endif
 
     // ========== Microsteps (SPI Drivers ) ================

--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -22,7 +22,7 @@
 // Grbl versioning system
 
 #define GRBL_VERSION "1.3a"
-#define GRBL_VERSION_BUILD "20200631"
+#define GRBL_VERSION_BUILD "20200704"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/grbl_limits.cpp
+++ b/Grbl_Esp32/grbl_limits.cpp
@@ -149,6 +149,9 @@ void limits_go_home(uint8_t cycle_mask) {
         sys.step_control = STEP_CONTROL_EXECUTE_SYS_MOTION; // Set to execute homing motion and clear existing flags.
         st_prep_buffer(); // Prep and fill segment buffer from newly planned block.
         st_wake_up(); // Initiate motion
+#ifdef USE_I2S_OUT
+        delay_ms(I2S_OUT_DELAY_MS);
+#endif
         do {
             if (approach) {
                 // Check limit state. Lock out cycle axes when they change.

--- a/Grbl_Esp32/grbl_limits.cpp
+++ b/Grbl_Esp32/grbl_limits.cpp
@@ -149,9 +149,6 @@ void limits_go_home(uint8_t cycle_mask) {
         sys.step_control = STEP_CONTROL_EXECUTE_SYS_MOTION; // Set to execute homing motion and clear existing flags.
         st_prep_buffer(); // Prep and fill segment buffer from newly planned block.
         st_wake_up(); // Initiate motion
-#ifdef USE_I2S_OUT
-        delay_ms(I2S_OUT_DELAY_MS);
-#endif
         do {
             if (approach) {
                 // Check limit state. Lock out cycle axes when they change.


### PR DESCRIPTION
~~When using TMC's StallGuard sensor-less homing on the I2S ShiftRegister board, a small delay was required at the beginning of Homing.~~
~~Besides that,~~ I'll fix some other things I noticed about the configuration values.
