### PR TITLE
Fixed python build problem

### DIFF
--- a/build-all.py
+++ b/build-all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Note: If you experience random errors running this script within
 # VSCode, try running it from a regular terminal window.  Some VSCode

--- a/build-machine.py
+++ b/build-machine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 # Compile Grbl_ESP32 for each of the machines defined in Machines/ .
 # Add-on files are built on top of a single base.

--- a/builder.py
+++ b/builder.py
@@ -22,6 +22,7 @@ def buildMachine(baseName, verbose=True, extraArgs=None):
     else:
         app = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=1)
         for line in app.stdout:
+            line = line.decode('utf8')
             if "Took" in line or 'Uploading' in line or "error" in line.lower():
                 print(line, end='')
     app.wait()


### PR DESCRIPTION
The python build scripts had a dependency on python 2.  Now they work with - and require - python 3.