### PR TITLE
Fix double-enabled probrem

### DIFF
--- a/configure-features.py
+++ b/configure-features.py
@@ -163,9 +163,9 @@ def changeConfig(src, enabled, disabled, verbose=False):
                 if len(enabled) > 0:
                     for name in enabled:
                         s = enablePrefix + name
-                        m = re.match(r'^s*//\s*#define\s+(' + s + r'.*)$', line)
+                        m = re.match(r'^s*(//)*\s*#define\s+(' + s + r'.*)$', line)
                         if m:
-                            dstLine = "#define " + m.group(1) + '\n'
+                            dstLine = "#define " + m.group(2) + '\n'
                             numEnabledDic[name] += 1
                             break
                 if len(disabled) > 0:


### PR DESCRIPTION
I found a bug in a feature definition script I wrote.
If you explicitly specify enable for a feature that has already been defined, it is doubly enabled.

Before fix:
```bash:
% ./configure-features.py -v -e WIFI -e BLUETOOTH -e SD_CARD
Config path: /Users/odaki/Documents/GitHub/Grbl_Esp32/Grbl_Esp32/config.h

#define ENABLE_BLUETOOTH // enable bluetooth

#define ENABLE_SD_CARD // enable use of SD Card to run jobs

#define ENABLE_WIFI //enable wifi

#if defined(ENABLE_WIFI) || defined(ENABLE_BLUETOOTH)
#define WIFI_OR_BLUETOOTH
#endif


#define ENABLE_HTTP //enable HTTP and all related services
#define ENABLE_OTA  //enable OTA
#define ENABLE_TELNET //enable telnet
#define ENABLE_TELNET_WELCOME_MSG //display welcome string when connect to telnet
#define ENABLE_MDNS //enable mDNS discovery
#define ENABLE_SSDP //enable UPNP discovery
#define ENABLE_NOTIFICATIONS //enable notifications

#define ENABLE_SERIAL2SOCKET_IN
#define ENABLE_SERIAL2SOCKET_OUT

// Captive portal is used when WiFi is in access point mode.  It lets the
// WebUI come up automatically in the browser, instead of requiring the user
// to browse manually to a default URL.  It works like airport and hotel
// WiFi that takes you a special page as soon as you connect to that AP.
#define ENABLE_CAPTIVE_PORTAL

// Warning! The current authentication implementation is too weak to provide
// security against an attacker, since passwords are stored and transmitted
// "in the clear" over unsecured channels.  It should be treated as a
// "friendly suggestion" to prevent unwitting dangerous actions, rather than
// as effective security against malice.
//#define ENABLE_AUTHENTICATION
#define ENABLE_SD_CARD
```
"ENABLE_SD_CARD" is double-enabled(See the last line).

After fix:
```bash:
% ./configure-features.py -v -e WIFI -e BLUETOOTH -e SD_CARD
Config path: /Users/odaki/Documents/GitHub/Grbl_Esp32/Grbl_Esp32/config.h

#define ENABLE_BLUETOOTH // enable bluetooth

#define ENABLE_SD_CARD // enable use of SD Card to run jobs

#define ENABLE_WIFI //enable wifi

#if defined(ENABLE_WIFI) || defined(ENABLE_BLUETOOTH)
#define WIFI_OR_BLUETOOTH
#endif


#define ENABLE_HTTP //enable HTTP and all related services
#define ENABLE_OTA  //enable OTA
#define ENABLE_TELNET //enable telnet
#define ENABLE_TELNET_WELCOME_MSG //display welcome string when connect to telnet
#define ENABLE_MDNS //enable mDNS discovery
#define ENABLE_SSDP //enable UPNP discovery
#define ENABLE_NOTIFICATIONS //enable notifications

#define ENABLE_SERIAL2SOCKET_IN
#define ENABLE_SERIAL2SOCKET_OUT

// Captive portal is used when WiFi is in access point mode.  It lets the
// WebUI come up automatically in the browser, instead of requiring the user
// to browse manually to a default URL.  It works like airport and hotel
// WiFi that takes you a special page as soon as you connect to that AP.
#define ENABLE_CAPTIVE_PORTAL

// Warning! The current authentication implementation is too weak to provide
// security against an attacker, since passwords are stored and transmitted
// "in the clear" over unsecured channels.  It should be treated as a
// "friendly suggestion" to prevent unwitting dangerous actions, rather than
// as effective security against malice.
//#define ENABLE_AUTHENTICATION
%
```
Now, "ENABLE_SD_CARD" has been defined only once.

Please merge the modified code with the PR.