### PR TITLE
Re fix reset

### DIFF
--- a/Grbl_Esp32/grbl.h
+++ b/Grbl_Esp32/grbl.h
@@ -22,7 +22,7 @@
 // Grbl versioning system
 
 #define GRBL_VERSION "1.3a"
-#define GRBL_VERSION_BUILD "20200725"
+#define GRBL_VERSION_BUILD "20200726"
 
 
 //#include <sdkconfig.h>

--- a/Grbl_Esp32/protocol.cpp
+++ b/Grbl_Esp32/protocol.cpp
@@ -99,7 +99,7 @@ err_t execute_line(char* line, uint8_t client, auth_t auth_level)
   GRBL PRIMARY LOOP:
 */
 void protocol_main_loop() {
-    empty_client_buffers();
+    serial_reset_read_buffer(CLIENT_ALL);
     empty_lines();
     //uint8_t client = CLIENT_SERIAL; // default client
     // Perform some machine checks to make sure everything is good to go.

--- a/Grbl_Esp32/serial.cpp
+++ b/Grbl_Esp32/serial.cpp
@@ -63,12 +63,6 @@ static TaskHandle_t serialCheckTaskHandle = 0;
 
 InputBuffer client_buffer[CLIENT_COUNT];  // create a buffer for each client
 
-void empty_client_buffers() {
-    for (uint8_t i = 0; i < CLIENT_COUNT; i++) {
-        client_buffer[i].end();
-    }
-}
-
 // Returns the number of bytes available in a client buffer.
 uint8_t serial_get_rx_buffer_available(uint8_t client) {
     return client_buffer[client].availableforwrite();
@@ -160,7 +154,7 @@ void serialCheckTask(void* pvParameters) {
 void serial_reset_read_buffer(uint8_t client) {
     for (uint8_t client_num = 0; client_num < CLIENT_COUNT; client_num++) {
         if (client == client_num || client == CLIENT_ALL)
-            client_buffer[client].begin();
+            client_buffer[client_num].begin();
     }
 }
 

--- a/Grbl_Esp32/serial.h
+++ b/Grbl_Esp32/serial.h
@@ -56,6 +56,4 @@ void execute_realtime_command(uint8_t command, uint8_t client);
 bool any_client_has_data();
 bool is_realtime_command(uint8_t data);
 
-void empty_client_buffers();
-
 #endif


### PR DESCRIPTION
The fix for ^x not clearing the input buffer can be done with an existing function so the addition of a new one was unnecessary.  The existing function had a bug so I fixed that first.