### PR TITLE
FIx the I2S stream generates a 3x faster pulse.

### DIFF
--- a/Grbl_Esp32/i2s_out.cpp
+++ b/Grbl_Esp32/i2s_out.cpp
@@ -101,8 +101,8 @@ static portMUX_TYPE i2s_out_spinlock = portMUX_INITIALIZER_UNLOCKED;
 static int i2s_out_initialized = 0;
 
 #    ifdef USE_I2S_OUT_STREAM
-static volatile uint32_t             i2s_out_pulse_period;
-static uint32_t                      i2s_out_remain_time_until_next_pulse;  // Time remaining until the next pulse (μsec)
+static volatile uint64_t             i2s_out_pulse_period;
+static uint64_t                      i2s_out_remain_time_until_next_pulse;  // Time remaining until the next pulse (μsec)
 static volatile i2s_out_pulse_func_t i2s_out_pulse_func;
 #    endif
 
@@ -339,10 +339,12 @@ static int IRAM_ATTR i2s_fillout_dma_buffer(lldesc_t* dma_desc) {
                 if (i2s_out_pulser_status == STEPPING) {
                     // fillout future DMA buffer (tail of the DMA buffer chains)
                     if (i2s_out_pulse_func != NULL) {
+                        uint32_t old_rw_pos = o_dma.rw_pos;
                         I2S_OUT_PULSER_EXIT_CRITICAL();   // Temporarily unlocked status lock as it may be locked in pulse callback.
                         (*i2s_out_pulse_func)();          // should be pushed into buffer max DMA_SAMPLE_SAFE_COUNT
                         I2S_OUT_PULSER_ENTER_CRITICAL();  // Lock again.
-                        i2s_out_remain_time_until_next_pulse = i2s_out_pulse_period;
+                        // Calcurate pulse period. About magic number 2, refer to the st_wake_up(). (Ad hoc delay value)
+                        i2s_out_remain_time_until_next_pulse = i2s_out_pulse_period - I2S_OUT_USEC_PER_PULSE * (o_dma.rw_pos - old_rw_pos) + 2;
                         if (i2s_out_pulser_status == WAITING) {
                             // i2s_out_set_passthrough() has called from the pulse function.
                             // It needs to go into pass-through mode.
@@ -610,9 +612,9 @@ int IRAM_ATTR i2s_out_set_stepping() {
     return 0;
 }
 
-int IRAM_ATTR i2s_out_set_pulse_period(uint32_t period) {
+int IRAM_ATTR i2s_out_set_pulse_period(uint64_t period) {
 #    ifdef USE_I2S_OUT_STREAM
-    i2s_out_pulse_period = period;
+    i2s_out_pulse_period = period * 1000000 / F_STEPPER_TIMER; // Use 64-bit values to avoid overflowing during the calculation.
 #    endif
     return 0;
 }

--- a/Grbl_Esp32/i2s_out.h
+++ b/Grbl_Esp32/i2s_out.h
@@ -164,10 +164,10 @@ int i2s_out_set_stepping();
 void i2s_out_delay();
 
 /*
-   Set the pulse callback period in microseconds
-   (like the timer period for the ISR)
+   Set the pulse callback period in ISR ticks.
+   (same value of the timer period for the ISR)
  */
-int i2s_out_set_pulse_period(uint32_t period);
+int i2s_out_set_pulse_period(uint64_t period);
 
 /*
    Register a callback function to generate pulse data

--- a/Grbl_Esp32/stepper.cpp
+++ b/Grbl_Esp32/stepper.cpp
@@ -1176,7 +1176,7 @@ void IRAM_ATTR Stepper_Timer_WritePeriod(uint64_t alarm_val) {
 #ifdef USE_I2S_OUT_STREAM
     // 1 tick = F_TIMERS / F_STEPPER_TIMER
     // Pulse ISR is called for each tick of alarm_val.
-    i2s_out_set_pulse_period(alarm_val / 60);
+    i2s_out_set_pulse_period(alarm_val);
 #else
     timer_set_alarm_value(STEP_TIMER_GROUP, STEP_TIMER_INDEX, alarm_val);
 #endif


### PR DESCRIPTION
**Phenomenon**
With the I2S stream enabled, the motor moves about three times as fast as the RMT step.

Reproduce steps:

1. change parameters for reproduce
$Stepper/Pulse=5
$Stepper/IdleTime=255
$X/StepsPerMm=5120.000
$X/MaxRate=1000.000
$X/Acceleration=1.000
$X/MaxTravel=300.000
2. move X axis 1 mm with F500
G0X1F500

The expected processing time is about 2.037s.
The actual processing time is about 0.75s, which is about three times faster.

**Root cause**
I completely misunderstood the calculation of the interruption interval.
I had assumed that the alarm_val used in the interrupt setting was μs/min.
The actual units were ticks/interupt.

For example (alarm_val = 32,549):
Correct value
1 / 20,000,000 * 32,549 = 0.00162745 s/int

Incorrectly calculated value(Approximately 1/3 of correct value):
32,549 / 60 / 10,000,000 = 0.00054248 s/int

**Fix**
Change to calculate the correct μsec interval from the tick value.
After the fix, I2S steps now generate a pulse similar to RMT steps when using I2S streams.

RMT steps:
![RMT_PLW4_IDL255_G0X1F500](https://user-images.githubusercontent.com/11240403/89710821-1f951180-d9c1-11ea-92d1-bb37eee432c6.png)

I2S stream steps:
![I2S_STREAM_PLW5_IDL255_G0X1F500](https://user-images.githubusercontent.com/11240403/89710829-2c196a00-d9c1-11ea-8dc4-fdf5e71b4924.png)

**Acknowledgments**
I would like to thank jesse schoch and William Curry for reporting on the issue.
I also thanks Mitch Bradley and Bart Dring for their help in investigating the cause of the problem.