### PR TITLE
Avoid reiterationIteration in spindle names

### DIFF
--- a/CodingStyle.md
+++ b/CodingStyle.md
@@ -51,7 +51,7 @@ have a single class.
 - Class names and namespace names are named `CamelCase`. Note that 
   class and namespace names should only start with an `_` if they are 
   (A) not in the global namespace and (b) should otherwise start with a digit.
-  For example `_10VSpindle`.
+  For example `_10V`.
 - Class member functions should be `snake_case`
 - Class member variables should be `_snake_case` with a leading `_`.
  

--- a/Grbl_Esp32/Grbl_Esp32.ino
+++ b/Grbl_Esp32/Grbl_Esp32.ino
@@ -87,7 +87,7 @@ void setup() {
     if (homing_enable->get())
         sys.state = STATE_ALARM;
 #endif
-    Spindles::Spindle::spindle_select();
+    Spindles::Spindle::select();
 #ifdef ENABLE_WIFI
     wifi_config.begin();
 #endif

--- a/Grbl_Esp32/src/Spindles/10vSpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/10vSpindle.cpp
@@ -27,7 +27,7 @@
 #include "10vSpindle.h"
 
 namespace Spindles {
-    void _10vSpindle::init() {
+    void _10v::init() {
         get_pins_and_settings();  // these gets the standard PWM settings, but many need to be changed for BESC
 
         // a couple more pins not inherited from PWM Spindle
@@ -48,8 +48,8 @@ namespace Spindles {
             return;  // We cannot continue without the output pin
         }
 
-        ledcSetup(_spindle_pwm_chan_num, (double)_pwm_freq, _pwm_precision);  // setup the channel
-        ledcAttachPin(_output_pin, _spindle_pwm_chan_num);                    // attach the PWM to the pin
+        ledcSetup(_pwm_chan_num, (double)_pwm_freq, _pwm_precision);  // setup the channel
+        ledcAttachPin(_output_pin, _pwm_chan_num);                    // attach the PWM to the pin
 
         pinMode(_enable_pin, OUTPUT);
         pinMode(_direction_pin, OUTPUT);
@@ -65,7 +65,7 @@ namespace Spindles {
     }
 
     // prints the startup message of the spindle config
-    void _10vSpindle::config_message() {
+    void _10v::config_message() {
         grbl_msg_sendf(CLIENT_SERIAL,
                        MSG_LEVEL_INFO,
                        "0-10V spindle Out:%s Enbl:%s, Dir:%s, Fwd:%s, Rev:%s, Freq:%dHz Res:%dbits",
@@ -78,7 +78,7 @@ namespace Spindles {
                        _pwm_precision);
     }
 
-    uint32_t _10vSpindle::set_rpm(uint32_t rpm) {
+    uint32_t _10v::set_rpm(uint32_t rpm) {
         uint32_t pwm_value;
 
         if (_output_pin == UNDEFINED_PIN)
@@ -104,7 +104,7 @@ namespace Spindles {
         return rpm;
     }
     /*
-	void _10vSpindle::set_state(uint8_t state, uint32_t rpm) {
+	void _10v::set_state(uint8_t state, uint32_t rpm) {
 		if (sys.abort)
 			return;   // Block during abort.
 
@@ -112,7 +112,7 @@ namespace Spindles {
 			sys.spindle_speed = 0;
 			stop();
 		} else {
-			set_spindle_dir_pin(state == SPINDLE_ENABLE_CW);
+			set_dir_pin(state == SPINDLE_ENABLE_CW);
 			set_rpm(rpm);
 		}
 
@@ -123,7 +123,7 @@ namespace Spindles {
 
 	*/
 
-    uint8_t _10vSpindle::get_state() {
+    uint8_t _10v::get_state() {
         if (_current_pwm_duty == 0 || _output_pin == UNDEFINED_PIN)
             return (SPINDLE_STATE_DISABLE);
         if (_direction_pin != UNDEFINED_PIN)
@@ -131,14 +131,14 @@ namespace Spindles {
         return (SPINDLE_STATE_CW);
     }
 
-    void _10vSpindle::stop() {
+    void _10v::stop() {
         // inverts are delt with in methods
         set_enable_pin(false);
         set_output(_pwm_off_value);
     }
 
-    void _10vSpindle::set_enable_pin(bool enable) {
-        //grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "_10vSpindle::set_enable_pin");
+    void _10v::set_enable_pin(bool enable) {
+        //grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "Spindle::_10v::set_enable_pin");
         if (_off_with_zero_speed && sys.spindle_speed == 0)
             enable = false;
 
@@ -155,8 +155,8 @@ namespace Spindles {
         }
     }
 
-    void _10vSpindle::set_spindle_dir_pin(bool Clockwise) {
-        //grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "_10vSpindle::set_spindle_dir_pin");
+    void _10v::set_dir_pin(bool Clockwise) {
+        //grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "Spindle::_10v::set_dir_pin");
         digitalWrite(_direction_pin, Clockwise);
         digitalWrite(_forward_pin, Clockwise);
         digitalWrite(_reverse_pin, !Clockwise);

--- a/Grbl_Esp32/src/Spindles/10vSpindle.h
+++ b/Grbl_Esp32/src/Spindles/10vSpindle.h
@@ -29,14 +29,14 @@
 #include "PWMSpindle.h"
 
 namespace Spindles {
-    class _10vSpindle : public PWMSpindle {
+    class _10v : public PWM {
     public:
-        _10vSpindle() = default;
+        _10v() = default;
 
-        _10vSpindle(const _10vSpindle&) = delete;
-        _10vSpindle(_10vSpindle&&)      = delete;
-        _10vSpindle& operator=(const _10vSpindle&) = delete;
-        _10vSpindle& operator=(_10vSpindle&&) = delete;
+        _10v(const _10v&) = delete;
+        _10v(_10v&&)      = delete;
+        _10v& operator=(const _10v&) = delete;
+        _10v& operator=(_10v&&) = delete;
 
         void     init() override;
         void     config_message() override;
@@ -46,13 +46,13 @@ namespace Spindles {
         uint8_t get_state() override;
         void    stop() override;
 
-        virtual ~_10vSpindle() {}
+        virtual ~_10v() {}
 
         uint8_t _forward_pin;
         uint8_t _reverse_pin;
 
     protected:
         void set_enable_pin(bool enable_pin) override;
-        void set_spindle_dir_pin(bool Clockwise) override;
+        void set_dir_pin(bool Clockwise) override;
     };
 }

--- a/Grbl_Esp32/src/Spindles/BESCSpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/BESCSpindle.cpp
@@ -52,7 +52,7 @@
 #define BESC_MAX_PULSE_CNT (uint16_t)(BESC_MAX_PULSE_SECS / BESC_PULSE_PERIOD * 65535.0)
 
 namespace Spindles {
-    void BESCSpindle::init() {
+    void BESC::init() {
         get_pins_and_settings();  // these gets the standard PWM settings, but many need to be changed for BESC
 
         if (_output_pin == UNDEFINED_PIN) {
@@ -69,8 +69,8 @@ namespace Spindles {
         _pwm_min_value = _pwm_off_value;
         _pwm_max_value = BESC_MAX_PULSE_CNT;
 
-        ledcSetup(_spindle_pwm_chan_num, (double)_pwm_freq, _pwm_precision);  // setup the channel
-        ledcAttachPin(_output_pin, _spindle_pwm_chan_num);                    // attach the PWM to the pin
+        ledcSetup(_pwm_chan_num, (double)_pwm_freq, _pwm_precision);  // setup the channel
+        ledcAttachPin(_output_pin, _pwm_chan_num);                    // attach the PWM to the pin
 
         pinMode(_enable_pin, OUTPUT);
 
@@ -82,7 +82,7 @@ namespace Spindles {
     }
 
     // prints the startup message of the spindle config
-    void BESCSpindle::config_message() {
+    void BESC::config_message() {
         grbl_msg_sendf(CLIENT_SERIAL,
                        MSG_LEVEL_INFO,
                        "BESC spindle on Pin:%s Min:%0.2fms Max:%0.2fms Freq:%dHz Res:%dbits",
@@ -93,7 +93,7 @@ namespace Spindles {
                        _pwm_precision);
     }
 
-    uint32_t BESCSpindle::set_rpm(uint32_t rpm) {
+    uint32_t BESC::set_rpm(uint32_t rpm) {
         uint32_t pwm_value;
 
         if (_output_pin == UNDEFINED_PIN)

--- a/Grbl_Esp32/src/Spindles/BESCSpindle.h
+++ b/Grbl_Esp32/src/Spindles/BESCSpindle.h
@@ -36,19 +36,19 @@
 #include "PWMSpindle.h"
 
 namespace Spindles {
-    class BESCSpindle : public PWMSpindle {
+    class BESC : public PWM {
     public:
-        BESCSpindle() = default;
+        BESC() = default;
 
-        BESCSpindle(const BESCSpindle&) = delete;
-        BESCSpindle(BESCSpindle&&)      = delete;
-        BESCSpindle& operator=(const BESCSpindle&) = delete;
-        BESCSpindle& operator=(BESCSpindle&&) = delete;
+        BESC(const BESC&) = delete;
+        BESC(BESC&&)      = delete;
+        BESC& operator=(const BESC&) = delete;
+        BESC& operator=(BESC&&) = delete;
 
         void     init() override;
         void     config_message() override;
         uint32_t set_rpm(uint32_t rpm) override;
 
-        virtual ~BESCSpindle() {}
+        virtual ~BESC() {}
     };
 }

--- a/Grbl_Esp32/src/Spindles/DacSpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/DacSpindle.cpp
@@ -24,8 +24,8 @@
 #include "DacSpindle.h"
 
 namespace Spindles {
-    // ======================================== DacSpindle ======================================
-    void DacSpindle::init() {
+    // ======================================== Dac ======================================
+    void Dac::init() {
         get_pins_and_settings();
 
         if (_output_pin == UNDEFINED_PIN)
@@ -52,7 +52,7 @@ namespace Spindles {
         config_message();
     }
 
-    void DacSpindle::config_message() {
+    void Dac::config_message() {
         grbl_msg_sendf(CLIENT_SERIAL,
                        MSG_LEVEL_INFO,
                        "DAC spindle Output:%s, Enbl:%s, Dir:%s, Res:8bits",
@@ -61,7 +61,7 @@ namespace Spindles {
                        pinName(_direction_pin).c_str());
     }
 
-    uint32_t DacSpindle::set_rpm(uint32_t rpm) {
+    uint32_t Dac::set_rpm(uint32_t rpm) {
         if (_output_pin == UNDEFINED_PIN)
             return rpm;
 
@@ -98,7 +98,7 @@ namespace Spindles {
         return rpm;
     }
 
-    void DacSpindle::set_output(uint32_t duty) {
+    void Dac::set_output(uint32_t duty) {
         if (_gpio_ok) {
             dacWrite(_output_pin, (uint8_t)duty);
         }

--- a/Grbl_Esp32/src/Spindles/DacSpindle.h
+++ b/Grbl_Esp32/src/Spindles/DacSpindle.h
@@ -28,20 +28,20 @@
 
 namespace Spindles {
     // This uses one of the (2) DAC pins on ESP32 to output a voltage
-    class DacSpindle : public PWMSpindle {
+    class Dac : public PWM {
     public:
-        DacSpindle() = default;
+        Dac() = default;
 
-        DacSpindle(const DacSpindle&) = delete;
-        DacSpindle(DacSpindle&&)      = delete;
-        DacSpindle& operator=(const DacSpindle&) = delete;
-        DacSpindle& operator=(DacSpindle&&) = delete;
+        Dac(const Dac&) = delete;
+        Dac(Dac&&)      = delete;
+        Dac& operator=(const Dac&) = delete;
+        Dac& operator=(Dac&&) = delete;
 
         void     init() override;
         void     config_message() override;
         uint32_t set_rpm(uint32_t rpm) override;
 
-        virtual ~DacSpindle() {}
+        virtual ~Dac() {}
 
     private:
         bool _gpio_ok;  // DAC is on a valid pin

--- a/Grbl_Esp32/src/Spindles/HuanyangSpindle.h
+++ b/Grbl_Esp32/src/Spindles/HuanyangSpindle.h
@@ -21,7 +21,7 @@
 #include "Spindle.h"
 
 namespace Spindles {
-    class HuanyangSpindle : public Spindle {
+    class Huanyang : public Spindle {
     private:
         uint16_t ModRTU_CRC(char* buf, int len);
 
@@ -37,12 +37,12 @@ namespace Spindles {
         bool     _task_running;
 
     public:
-        HuanyangSpindle() : _task_running(false) {}
+        Huanyang() : _task_running(false) {}
 
-        HuanyangSpindle(const HuanyangSpindle&) = delete;
-        HuanyangSpindle(HuanyangSpindle&&)      = delete;
-        HuanyangSpindle& operator=(const HuanyangSpindle&) = delete;
-        HuanyangSpindle& operator=(HuanyangSpindle&&) = delete;
+        Huanyang(const Huanyang&) = delete;
+        Huanyang(Huanyang&&)      = delete;
+        Huanyang& operator=(const Huanyang&) = delete;
+        Huanyang& operator=(Huanyang&&) = delete;
 
         void        init();
         void        config_message();
@@ -53,7 +53,7 @@ namespace Spindles {
         static void read_value(uint8_t reg);
         static void add_ModRTU_CRC(char* buf, int full_msg_len);
 
-        virtual ~HuanyangSpindle() {}
+        virtual ~Huanyang() {}
 
     protected:
         uint32_t _min_rpm;

--- a/Grbl_Esp32/src/Spindles/Laser.cpp
+++ b/Grbl_Esp32/src/Spindles/Laser.cpp
@@ -1,7 +1,7 @@
 /*
     Laser.cpp
 
-    This is similar the the PWM Spindle except that it allows the
+    This is similar to the PWM Spindle except that it allows the
     M4 speed vs. power copensation.
 
     Part of Grbl_ESP32
@@ -37,6 +37,6 @@ namespace Spindles {
                        _pwm_precision,
                        isRateAdjusted());  // the current mode
 
-        use_delays = false;  // this will override the value set in PWMSpindle intit()
+        use_delays = false;  // this will override the value set in Spindle::PWM::init()
     }
 }

--- a/Grbl_Esp32/src/Spindles/Laser.h
+++ b/Grbl_Esp32/src/Spindles/Laser.h
@@ -3,7 +3,7 @@
 /*
 	Laser.h
 
-	This is similar the the PWM Spindle except that it allows the
+	This is similar to the PWM Spindle except that it allows the
 	M4 speed vs. power copensation.
 
 	Part of Grbl_ESP32
@@ -25,7 +25,7 @@
 
 namespace Spindles {
     // this is the same as a PWM spindle but the M4 compensation is supported.
-    class Laser : public PWMSpindle {
+    class Laser : public PWM {
     public:
         Laser() = default;
 

--- a/Grbl_Esp32/src/Spindles/NullSpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/NullSpindle.cpp
@@ -22,17 +22,17 @@
 #include "NullSpindle.h"
 
 namespace Spindles {
-    // ======================= NullSpindle ==============================
-    // NullSpindle is just bunch of do nothing (ignore) methods to be used when you don't want a spindle
+    // ======================= Null ==============================
+    // Null is just bunch of do nothing (ignore) methods to be used when you don't want a spindle
 
-    void NullSpindle::init() {
+    void Null::init() {
         is_reversable = false;
         use_delays    = false;
         config_message();
     }
-    uint32_t NullSpindle::set_rpm(uint32_t rpm) { return rpm; }
-    void     NullSpindle::set_state(uint8_t state, uint32_t rpm) {}
-    uint8_t  NullSpindle::get_state() { return (SPINDLE_STATE_DISABLE); }
-    void     NullSpindle::stop() {}
-    void     NullSpindle::config_message() { grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "No spindle"); }
+    uint32_t Null::set_rpm(uint32_t rpm) { return rpm; }
+    void     Null::set_state(uint8_t state, uint32_t rpm) {}
+    uint8_t  Null::get_state() { return (SPINDLE_STATE_DISABLE); }
+    void     Null::stop() {}
+    void     Null::config_message() { grbl_msg_sendf(CLIENT_SERIAL, MSG_LEVEL_INFO, "No spindle"); }
 }

--- a/Grbl_Esp32/src/Spindles/NullSpindle.h
+++ b/Grbl_Esp32/src/Spindles/NullSpindle.h
@@ -26,14 +26,14 @@
 namespace Spindles {
     // This is a dummy spindle that has no I/O.
     // It is used to ignore spindle commands when no spinde is desired
-    class NullSpindle : public Spindle {
+    class Null : public Spindle {
     public:
-        NullSpindle() = default;
+        Null() = default;
 
-        NullSpindle(const NullSpindle&) = delete;
-        NullSpindle(NullSpindle&&)      = delete;
-        NullSpindle& operator=(const NullSpindle&) = delete;
-        NullSpindle& operator=(NullSpindle&&) = delete;
+        Null(const Null&) = delete;
+        Null(Null&&)      = delete;
+        Null& operator=(const Null&) = delete;
+        Null& operator=(Null&&) = delete;
 
         void     init() override;
         uint32_t set_rpm(uint32_t rpm) override;
@@ -42,6 +42,6 @@ namespace Spindles {
         void     stop() override;
         void     config_message() override;
 
-        virtual ~NullSpindle() {}
+        virtual ~Null() {}
     };
 }

--- a/Grbl_Esp32/src/Spindles/PWMSpindle.h
+++ b/Grbl_Esp32/src/Spindles/PWMSpindle.h
@@ -25,14 +25,14 @@
 
 namespace Spindles {
     // This adds support for PWM
-    class PWMSpindle : public Spindle {
+    class PWM : public Spindle {
     public:
-        PWMSpindle() = default;
+        PWM() = default;
 
-        PWMSpindle(const PWMSpindle&) = delete;
-        PWMSpindle(PWMSpindle&&)      = delete;
-        PWMSpindle& operator=(const PWMSpindle&) = delete;
-        PWMSpindle& operator=(PWMSpindle&&) = delete;
+        PWM(const PWM&) = delete;
+        PWM(PWM&&)      = delete;
+        PWM& operator=(const PWM&) = delete;
+        PWM& operator=(PWM&&) = delete;
 
         void             init() override;
         virtual uint32_t set_rpm(uint32_t rpm) override;
@@ -41,7 +41,7 @@ namespace Spindles {
         void             stop() override;
         void             config_message() override;
 
-        virtual ~PWMSpindle() {}
+        virtual ~PWM() {}
 
     protected:
         int32_t  _current_pwm_duty;
@@ -53,7 +53,7 @@ namespace Spindles {
         uint8_t  _output_pin;
         uint8_t  _enable_pin;
         uint8_t  _direction_pin;
-        uint8_t  _spindle_pwm_chan_num;
+        uint8_t  _pwm_chan_num;
         uint32_t _pwm_freq;
         uint32_t _pwm_period;  // how many counts in 1 period
         uint8_t  _pwm_precision;
@@ -62,7 +62,7 @@ namespace Spindles {
         bool     _invert_pwm;
         //uint32_t _pwm_gradient; // Precalulated value to speed up rpm to PWM conversions.
 
-        virtual void set_spindle_dir_pin(bool Clockwise);
+        virtual void set_dir_pin(bool Clockwise);
         virtual void set_output(uint32_t duty);
         virtual void set_enable_pin(bool enable_pin);
 

--- a/Grbl_Esp32/src/Spindles/RelaySpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/RelaySpindle.cpp
@@ -21,13 +21,13 @@
 */
 #include "RelaySpindle.h"
 
-// ========================= RelaySpindle ==================================
+// ========================= Relay ==================================
 
 namespace Spindles {
     /*
-    This is a sub class of PWMSpindle but is a digital rather than PWM output
+    This is a sub class of PWM but is a digital rather than PWM output
 */
-    void RelaySpindle::init() {
+    void Relay::init() {
         get_pins_and_settings();
 
         if (_output_pin == UNDEFINED_PIN)
@@ -44,7 +44,7 @@ namespace Spindles {
     }
 
     // prints the startup message of the spindle config
-    void RelaySpindle ::config_message() {
+    void Relay ::config_message() {
         grbl_msg_sendf(CLIENT_SERIAL,
                        MSG_LEVEL_INFO,
                        "Relay spindle Output:%s, Enbl:%s, Dir:%s",
@@ -53,7 +53,7 @@ namespace Spindles {
                        pinName(_direction_pin).c_str());
     }
 
-    uint32_t RelaySpindle::set_rpm(uint32_t rpm) {
+    uint32_t Relay::set_rpm(uint32_t rpm) {
         if (_output_pin == UNDEFINED_PIN)
             return rpm;
 
@@ -63,7 +63,7 @@ namespace Spindles {
         return rpm;
     }
 
-    void RelaySpindle::set_output(uint32_t duty) {
+    void Relay::set_output(uint32_t duty) {
 #ifdef INVERT_SPINDLE_PWM
         duty = (duty == 0);  // flip duty
 #endif

--- a/Grbl_Esp32/src/Spindles/RelaySpindle.h
+++ b/Grbl_Esp32/src/Spindles/RelaySpindle.h
@@ -25,20 +25,20 @@
 
 namespace Spindles {
     // This is for an on/off spindle all RPMs above 0 are on
-    class RelaySpindle : public PWMSpindle {
+    class Relay : public PWM {
     public:
-        RelaySpindle() = default;
+        Relay() = default;
 
-        RelaySpindle(const RelaySpindle&) = delete;
-        RelaySpindle(RelaySpindle&&)      = delete;
-        RelaySpindle& operator=(const RelaySpindle&) = delete;
-        RelaySpindle& operator=(RelaySpindle&&) = delete;
+        Relay(const Relay&) = delete;
+        Relay(Relay&&)      = delete;
+        Relay& operator=(const Relay&) = delete;
+        Relay& operator=(Relay&&) = delete;
 
         void     init() override;
         void     config_message() override;
         uint32_t set_rpm(uint32_t rpm) override;
 
-        virtual ~RelaySpindle() {}
+        virtual ~Relay() {}
 
     protected:
         void set_output(uint32_t duty);

--- a/Grbl_Esp32/src/Spindles/Spindle.cpp
+++ b/Grbl_Esp32/src/Spindles/Spindle.cpp
@@ -41,26 +41,26 @@
 namespace Spindles {
     // An instance of each type of spindle is created here.
     // This allows the spindle to be dynamicly switched
-    NullSpindle     null_spindle;
-    PWMSpindle      pwm_spindle;
-    RelaySpindle    relay_spindle;
+    Null     null;
+    PWM      pwm;
+    Relay    relay;
     Laser           laser;
-    DacSpindle      dac_spindle;
-    HuanyangSpindle huanyang_spindle;
-    BESCSpindle     besc_spindle;
-    _10vSpindle     _10v_spindle;
+    Dac      dac;
+    Huanyang huanyang;
+    BESC     besc;
+    _10v     _10v;
 
-    void Spindle::spindle_select() {
+    void Spindle::select() {
         switch (spindle_type->get()) {
-            case SPINDLE_TYPE_PWM: spindle = &pwm_spindle; break;
-            case SPINDLE_TYPE_RELAY: spindle = &relay_spindle; break;
+            case SPINDLE_TYPE_PWM: spindle = &pwm; break;
+            case SPINDLE_TYPE_RELAY: spindle = &relay; break;
             case SPINDLE_TYPE_LASER: spindle = &laser; break;
-            case SPINDLE_TYPE_DAC: spindle = &dac_spindle; break;
-            case SPINDLE_TYPE_HUANYANG: spindle = &huanyang_spindle; break;
-            case SPINDLE_TYPE_BESC: spindle = &besc_spindle; break;
-            case SPINDLE_TYPE_10V: spindle = &_10v_spindle; break;
+            case SPINDLE_TYPE_DAC: spindle = &dac; break;
+            case SPINDLE_TYPE_HUANYANG: spindle = &huanyang; break;
+            case SPINDLE_TYPE_BESC: spindle = &besc; break;
+            case SPINDLE_TYPE_10V: spindle = &_10v; break;
             case SPINDLE_TYPE_NONE:
-            default: spindle = &null_spindle; break;
+            default: spindle = &null; break;
         }
 
         spindle->init();
@@ -72,7 +72,7 @@ namespace Spindles {
         return false;  // default for basic spindle is false
     }
 
-    void Spindle::spindle_sync(uint8_t state, uint32_t rpm) {
+    void Spindle::sync(uint8_t state, uint32_t rpm) {
         if (sys.state == STATE_CHECK_MODE)
             return;
         protocol_buffer_synchronize();  // Empty planner buffer to ensure spindle is set when programmed.

--- a/Grbl_Esp32/src/Spindles/Spindle.h
+++ b/Grbl_Esp32/src/Spindles/Spindle.h
@@ -64,7 +64,7 @@ namespace Spindles {
         virtual void     stop()                                 = 0;
         virtual void     config_message()                       = 0;
         virtual bool     isRateAdjusted();
-        virtual void     spindle_sync(uint8_t state, uint32_t rpm);
+        virtual void     sync(uint8_t state, uint32_t rpm);
 
         virtual ~Spindle() {}
 
@@ -72,7 +72,7 @@ namespace Spindles {
         bool    use_delays;  // will SpinUp and SpinDown delays be used.
         uint8_t _current_state;
 
-        static void spindle_select();
+        static void select();
     };
 
 }

--- a/Grbl_Esp32/src/gcode.cpp
+++ b/Grbl_Esp32/src/gcode.cpp
@@ -1122,9 +1122,9 @@ uint8_t gc_execute_line(char* line, uint8_t client) {
         if (gc_state.modal.spindle != SPINDLE_DISABLE) {
             if (bit_isfalse(gc_parser_flags, GC_PARSER_LASER_ISMOTION)) {
                 if (bit_istrue(gc_parser_flags, GC_PARSER_LASER_DISABLE))
-                    spindle->spindle_sync(gc_state.modal.spindle, 0);
+                    spindle->sync(gc_state.modal.spindle, 0);
                 else
-                    spindle->spindle_sync(gc_state.modal.spindle, (uint32_t)gc_block.values.s);
+                    spindle->sync(gc_state.modal.spindle, (uint32_t)gc_block.values.s);
             }
         }
         gc_state.spindle_speed = gc_block.values.s;  // Update spindle speed state.
@@ -1146,7 +1146,7 @@ uint8_t gc_execute_line(char* line, uint8_t client) {
         // Update spindle control and apply spindle speed when enabling it in this block.
         // NOTE: All spindle state changes are synced, even in laser mode. Also, pl_data,
         // rather than gc_state, is used to manage laser state for non-laser motions.
-        spindle->spindle_sync(gc_block.modal.spindle, (uint32_t)pl_data->spindle_speed);
+        spindle->sync(gc_block.modal.spindle, (uint32_t)pl_data->spindle_speed);
         gc_state.modal.spindle = gc_block.modal.spindle;
     }
     pl_data->condition |= gc_state.modal.spindle;  // Set condition flag for planner use.


### PR DESCRIPTION
When we have a namespace, we should use it.