### PR TITLE
Fix file names in comment blocks

### DIFF
--- a/Grbl_Esp32/Custom/esp32_printer_controller.cpp
+++ b/Grbl_Esp32/Custom/esp32_printer_controller.cpp
@@ -1,5 +1,5 @@
 /*
-	custom_code_template.cpp (copy and use your machine name)
+	esp32_printer_controller.cpp (copy and use your machine name)
 	Part of Grbl_ESP32
 
 	copyright (c) 2020 -	Bart Dring. This file was intended for use on the ESP32

--- a/Grbl_Esp32/src/Config.h
+++ b/Grbl_Esp32/src/Config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  config.h - compile time configuration
+  Config.h - compile time configuration
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC
@@ -413,7 +413,7 @@ Some features should not be changed. See notes below.
 // smoothing the stepping of multi-axis motions. This feature smooths motion particularly at low step
 // frequencies below 10kHz, where the aliasing between axes of multi-axis motions can cause audible
 // noise and shake your machine. At even lower step frequencies, AMASS adapts and provides even better
-// step smoothing. See stepper.c for more details on the AMASS system works.
+// step smoothing. See Stepper.c for more details on the AMASS system works.
 #define ADAPTIVE_MULTI_AXIS_STEP_SMOOTHING  // Default enabled. Comment to disable.
 
 // Sets the maximum step rate allowed to be written as a Grbl setting. This option enables an error

--- a/Grbl_Esp32/src/CoolantControl.cpp
+++ b/Grbl_Esp32/src/CoolantControl.cpp
@@ -1,5 +1,5 @@
 /*
-  coolant_control.c - coolant control methods
+  CoolantControl.c - coolant control methods
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/CoolantControl.cpp
+++ b/Grbl_Esp32/src/CoolantControl.cpp
@@ -1,5 +1,5 @@
 /*
-  CoolantControl.c - coolant control methods
+  CoolantControl.cpp - coolant control methods
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/CoolantControl.h
+++ b/Grbl_Esp32/src/CoolantControl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  coolant_control.h - spindle control methods
+  CoolantControl.h - spindle control methods
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Defaults.h
+++ b/Grbl_Esp32/src/Defaults.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  defaults.h - defaults settings configuration file
+  Defaults.h - defaults settings configuration file
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Eeprom.cpp
+++ b/Grbl_Esp32/src/Eeprom.cpp
@@ -1,5 +1,5 @@
 /*
-  eeprom.cpp - Header for system level commands and real-time processes
+  Eeprom.cpp - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/Eeprom.h
+++ b/Grbl_Esp32/src/Eeprom.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  eeprom.h - Header for system level commands and real-time processes
+  Eeprom.h - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/GCode.cpp
+++ b/Grbl_Esp32/src/GCode.cpp
@@ -1,5 +1,5 @@
 /*
-  gcode.c - rs274/ngc parser.
+  GCode.c - rs274/ngc parser.
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/GCode.cpp
+++ b/Grbl_Esp32/src/GCode.cpp
@@ -1,5 +1,5 @@
 /*
-  GCode.c - rs274/ngc parser.
+  GCode.cpp - rs274/ngc parser.
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/GCode.h
+++ b/Grbl_Esp32/src/GCode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  Gcode.h - rs274/ngc parser.
+  GCode.h - rs274/ngc parser.
   Part of Grbl
 
   Copyright (c) 2011-2015 Sungeun K. Jeon

--- a/Grbl_Esp32/src/GCode.h
+++ b/Grbl_Esp32/src/GCode.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  gcode.h - rs274/ngc parser.
+  Gcode.h - rs274/ngc parser.
   Part of Grbl
 
   Copyright (c) 2011-2015 Sungeun K. Jeon

--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  grbl.h - Header for system level commands and real-time processes
+  Grbl.h - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 
@@ -38,7 +38,6 @@
 // Define the Grbl system include files. NOTE: Do not alter organization.
 #include "Config.h"
 #include "NutsBolts.h"
-#include "TDef.h"
 
 #include "Defaults.h"
 #include "SettingsStorage.h"

--- a/Grbl_Esp32/src/I2SOut.cpp
+++ b/Grbl_Esp32/src/I2SOut.cpp
@@ -1,5 +1,5 @@
 /*
-    i2s_out.cpp
+    I2SOut.cpp
     Part of Grbl_ESP32
 
     Basic GPIO expander using the ESP32 I2S peripheral (output)

--- a/Grbl_Esp32/src/I2SOut.h
+++ b/Grbl_Esp32/src/I2SOut.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-    i2s_out.h
+    I2SOut.h
     Part of Grbl_ESP32
     Header for basic GPIO expander using the ESP32 I2S peripheral
     2020    - Michiyasu Odaki

--- a/Grbl_Esp32/src/Jog.cpp
+++ b/Grbl_Esp32/src/Jog.cpp
@@ -1,5 +1,5 @@
 /*
-  jog.h - Jogging methods
+  Jog.h - Jogging methods
   Part of Grbl
 
   Copyright (c) 2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Jog.cpp
+++ b/Grbl_Esp32/src/Jog.cpp
@@ -1,5 +1,5 @@
 /*
-  Jog.h - Jogging methods
+  Jog.cpp - Jogging methods
   Part of Grbl
 
   Copyright (c) 2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Jog.h
+++ b/Grbl_Esp32/src/Jog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  jog.h - Jogging methods
+  Jog.h - Jogging methods
   Part of Grbl
 
   Copyright (c) 2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Limits.cpp
+++ b/Grbl_Esp32/src/Limits.cpp
@@ -1,5 +1,5 @@
 /*
-  limits.c - code pertaining to limit-switches and performing the homing cycle
+  Limits.cpp - code pertaining to limit-switches and performing the homing cycle
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Limits.h
+++ b/Grbl_Esp32/src/Limits.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  limits.h - code pertaining to limit-switches and performing the homing cycle
+  Limits.h - code pertaining to limit-switches and performing the homing cycle
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Machine.h
+++ b/Grbl_Esp32/src/Machine.h
@@ -3,11 +3,6 @@
 // This file is where you choose the machine type, by including
 // one or more machine definition files as described below.
 
-/*
-PWM
-    Tested on arc_arrow.nc
-*/
-
 #ifndef MACHINE_FILENAME
 
 // !!! For initial testing, start with test_drive.h which disables

--- a/Grbl_Esp32/src/Machine.h
+++ b/Grbl_Esp32/src/Machine.h
@@ -6,9 +6,6 @@
 /*
 PWM
     Tested on arc_arrow.nc
-    
-
-
 */
 
 #ifndef MACHINE_FILENAME

--- a/Grbl_Esp32/src/Machines/4axis_external_driver.h
+++ b/Grbl_Esp32/src/Machines/4axis_external_driver.h
@@ -2,7 +2,7 @@
 // clang-format off
 
 /*
-    4axis_external_driver_4x.h
+    4axis_external_driver.h
     Part of Grbl_ESP32
 
     Pin assignments for the buildlog.net 4-axis external driver board

--- a/Grbl_Esp32/src/Machines/mpcnc_v1p1.h
+++ b/Grbl_Esp32/src/Machines/mpcnc_v1p1.h
@@ -2,7 +2,7 @@
 // clang-format off
 
 /*
-    mpcnc.h
+    mpcnc_v1p1.h
     Part of Grbl_ESP32
 
     Pin assignments for the Buildlog.net MPCNC controller

--- a/Grbl_Esp32/src/Machines/spindle_class_test.h
+++ b/Grbl_Esp32/src/Machines/spindle_class_test.h
@@ -2,7 +2,7 @@
 // clang-format off
 
 /*
-    3axis_v4.h
+    spindle_class_test.h
     Part of Grbl_ESP32
 
     Pin assignments for the ESP32 Development Controller, v4.1 and later.

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -1,5 +1,5 @@
 /*
-  motion_control.c - high level interface for issuing motion commands
+  MotionControl.c - high level interface for issuing motion commands
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -1,5 +1,5 @@
 /*
-  MotionControl.c - high level interface for issuing motion commands
+  MotionControl.cpp - high level interface for issuing motion commands
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC
@@ -240,7 +240,7 @@ void mc_homing_cycle(uint8_t cycle_mask) {
 #endif
         // Check and abort homing cycle, if hard limits are already enabled. Helps prevent problems
         // with machines with limits wired on both ends of travel to one limit pin.
-        // TODO: Move the pin-specific LIMIT_PIN call to limits.c as a function.
+        // TODO: Move the pin-specific LIMIT_PIN call to Limits.cpp as a function.
 #ifdef LIMITS_TWO_SWITCHES_ON_AXES
     if (limits_get_state()) {
         mc_reset();  // Issue system reset and ensure spindle and coolant are shutdown.

--- a/Grbl_Esp32/src/MotionControl.h
+++ b/Grbl_Esp32/src/MotionControl.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  motion_control.h - high level interface for issuing motion commands
+  MotionControl.h - high level interface for issuing motion commands
   Part of Grbl
 
   Copyright (c) 2011-2015 Sungeun K. Jeon

--- a/Grbl_Esp32/src/Motors/Motor.cpp
+++ b/Grbl_Esp32/src/Motors/Motor.cpp
@@ -1,5 +1,5 @@
 /*
-    MotorClass.cpp
+    Motor.cpp
     Part of Grbl_ESP32
     2020 -	Bart Dring
     Grbl is free software: you can redistribute it and/or modify

--- a/Grbl_Esp32/src/Motors/Motors.cpp
+++ b/Grbl_Esp32/src/Motors/Motors.cpp
@@ -1,5 +1,5 @@
 /*
-	Motor.cpp
+	Motors.cpp
 	Part of Grbl_ESP32
 	2020 -	Bart Dring
 	Grbl is free software: you can redistribute it and/or modify

--- a/Grbl_Esp32/src/Motors/Motors.cpp
+++ b/Grbl_Esp32/src/Motors/Motors.cpp
@@ -1,5 +1,5 @@
 /*
-	MotorClass.cpp
+	Motor.cpp
 	Part of Grbl_ESP32
 	2020 -	Bart Dring
 	Grbl is free software: you can redistribute it and/or modify

--- a/Grbl_Esp32/src/Motors/Motors.h
+++ b/Grbl_Esp32/src/Motors/Motors.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-	Motor.h
+	Motors.h
 	Header file for Motor Classes
 	Here is the hierarchy
 		Motor

--- a/Grbl_Esp32/src/Motors/RcServo.cpp
+++ b/Grbl_Esp32/src/Motors/RcServo.cpp
@@ -1,5 +1,5 @@
 /*
-    RcServoServoClass.cpp
+    RcServo.cpp
 
     This allows an RcServo to be used like any other motor. Serrvos
     do have limitation in travel and speed, so you do need to respect that.

--- a/Grbl_Esp32/src/Motors/RcServo.h
+++ b/Grbl_Esp32/src/Motors/RcServo.h
@@ -2,7 +2,7 @@
 
 /*
     RcServo.h
-    
+
     Part of Grbl_ESP32
 
     2020 -	Bart Dring

--- a/Grbl_Esp32/src/Motors/StandardStepper.cpp
+++ b/Grbl_Esp32/src/Motors/StandardStepper.cpp
@@ -1,5 +1,5 @@
 /*
-    StandardStepperClass.cpp
+    StandardStepper.cpp
 
     This is used for a stepper motor that just requires step and direction
     pins.

--- a/Grbl_Esp32/src/Motors/TrinamicDriver.cpp
+++ b/Grbl_Esp32/src/Motors/TrinamicDriver.cpp
@@ -1,5 +1,5 @@
 /*
-    TrinamicDriverClass.cpp
+    TrinamicDriver.cpp
     This is used for Trinamic SPI controlled stepper motor drivers.
 
     Part of Grbl_ESP32

--- a/Grbl_Esp32/src/Motors/TrinamicDriver.h
+++ b/Grbl_Esp32/src/Motors/TrinamicDriver.h
@@ -2,11 +2,11 @@
 
 /*
     TrinamicDriver.h
-    
+
     Part of Grbl_ESP32
 
-    2020 -	Bart Dring
-    
+    Copyright 2020 -	Bart Dring
+
     Grbl is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/Grbl_Esp32/src/Motors/TrinamicDriver.h
+++ b/Grbl_Esp32/src/Motors/TrinamicDriver.h
@@ -5,7 +5,7 @@
 
     Part of Grbl_ESP32
 
-    Copyright 2020 -	Bart Dring
+    2020 -	Bart Dring
 
     Grbl is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/Grbl_Esp32/src/NutsBolts.cpp
+++ b/Grbl_Esp32/src/NutsBolts.cpp
@@ -1,5 +1,5 @@
 /*
-  NutsBolts.c - Shared functions
+  NutsBolts.cpp - Shared functions
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/NutsBolts.cpp
+++ b/Grbl_Esp32/src/NutsBolts.cpp
@@ -1,5 +1,5 @@
 /*
-  nuts_bolts.c - Shared functions
+  NutsBolts.c - Shared functions
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/NutsBolts.h
+++ b/Grbl_Esp32/src/NutsBolts.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  nuts_bolts.h - Header for system level commands and real-time processes
+  NutsBolts.h - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/Planner.cpp
+++ b/Grbl_Esp32/src/Planner.cpp
@@ -1,5 +1,5 @@
 /*
-  Planner.c - buffers movement commands and manages the acceleration profile plan
+  Planner.cpp - buffers movement commands and manages the acceleration profile plan
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Planner.cpp
+++ b/Grbl_Esp32/src/Planner.cpp
@@ -1,5 +1,5 @@
 /*
-  planner.c - buffers movement commands and manages the acceleration profile plan
+  Planner.c - buffers movement commands and manages the acceleration profile plan
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Planner.h
+++ b/Grbl_Esp32/src/Planner.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  planner.h - buffers movement commands and manages the acceleration profile plan
+  Planner.h - buffers movement commands and manages the acceleration profile plan
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Probe.cpp
+++ b/Grbl_Esp32/src/Probe.cpp
@@ -1,5 +1,5 @@
 /*
-  probe.c - code pertaining to probing methods
+  Probe.c - code pertaining to probing methods
   Part of Grbl
 
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Probe.cpp
+++ b/Grbl_Esp32/src/Probe.cpp
@@ -1,5 +1,5 @@
 /*
-  Probe.c - code pertaining to probing methods
+  Probe.cpp - code pertaining to probing methods
   Part of Grbl
 
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Probe.h
+++ b/Grbl_Esp32/src/Probe.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  probe.h - code pertaining to probing methods
+  Probe.h - code pertaining to probing methods
   Part of Grbl
 
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Protocol.cpp
+++ b/Grbl_Esp32/src/Protocol.cpp
@@ -1,5 +1,5 @@
 /*
-  Protocol.c - controls Grbl execution protocol and procedures
+  Protocol.cpp - controls Grbl execution protocol and procedures
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Protocol.cpp
+++ b/Grbl_Esp32/src/Protocol.cpp
@@ -1,5 +1,5 @@
 /*
-  protocol.c - controls Grbl execution protocol and procedures
+  Protocol.c - controls Grbl execution protocol and procedures
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Protocol.h
+++ b/Grbl_Esp32/src/Protocol.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  protocol.h - controls Grbl execution protocol and procedures
+  Protocol.h - controls Grbl execution protocol and procedures
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Report.cpp
+++ b/Grbl_Esp32/src/Report.cpp
@@ -1,5 +1,5 @@
 /*
-  Report.c - reporting and messaging methods
+  Report.cpp - reporting and messaging methods
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC
@@ -24,7 +24,7 @@
 /*
   This file functions as the primary feedback interface for Grbl. Any outgoing data, such
   as the protocol status messages, feedback messages, and status reports, are stored here.
-  For the most part, these functions primarily are called from protocol.c methods. If a
+  For the most part, these functions primarily are called from Protocol.cpp methods. If a
   different style feedback is desired (i.e. JSON), then a user can change these following
   methods to accommodate their needs.
 

--- a/Grbl_Esp32/src/Report.cpp
+++ b/Grbl_Esp32/src/Report.cpp
@@ -1,5 +1,5 @@
 /*
-  report.c - reporting and messaging methods
+  Report.c - reporting and messaging methods
   Part of Grbl
 
   Copyright (c) 2012-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Report.h
+++ b/Grbl_Esp32/src/Report.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  report.h - Header for system level commands and real-time processes
+  Report.h - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/SDCard.cpp
+++ b/Grbl_Esp32/src/SDCard.cpp
@@ -1,5 +1,5 @@
 /*
-  grbl_sd.cpp - Adds SD Card Features to Grbl_ESP32
+  SDCard.cpp - Adds SD Card Features to Grbl_ESP32
   Part of Grbl_ESP32
 
   Copyright (c) 2018 Barton Dring Buildlog.net

--- a/Grbl_Esp32/src/Serial.cpp
+++ b/Grbl_Esp32/src/Serial.cpp
@@ -1,5 +1,5 @@
 /*
-  serial.cpp - Header for system level commands and real-time processes
+  Serial.cpp - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/Serial.h
+++ b/Grbl_Esp32/src/Serial.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  serial.h - Header for system level commands and real-time processes
+  Serial.h - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/ServoAxis.cpp
+++ b/Grbl_Esp32/src/ServoAxis.cpp
@@ -1,5 +1,5 @@
 /*
-  servo_axis.cpp
+  ServoAxis.cpp
   Part of Grbl_ESP32
 
 	copyright (c) 2018 -	Bart Dring. This file was intended for use on the ESP32
@@ -18,7 +18,7 @@
   You should have received a copy of the GNU General Public License
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 
-	See servo_axis.h for more details
+	See ServoAxis.h for more details
 
 */
 

--- a/Grbl_Esp32/src/ServoAxis.h
+++ b/Grbl_Esp32/src/ServoAxis.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  solenoid_pen.h
+  ServoAxis.h
   Part of Grbl_ESP32
 
 	copyright (c) 2019 -	Bart Dring. This file was intended for use on the ESP32

--- a/Grbl_Esp32/src/SettingsStorage.cpp
+++ b/Grbl_Esp32/src/SettingsStorage.cpp
@@ -1,5 +1,5 @@
 /*
-  SettingsStorage.c - EEPROM configuration handling
+  SettingsStorage.cpp - EEPROM configuration handling
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/SettingsStorage.cpp
+++ b/Grbl_Esp32/src/SettingsStorage.cpp
@@ -1,5 +1,5 @@
 /*
-  settings.c - eeprom configuration handling
+  SettingsStorage.c - EEPROM configuration handling
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/SettingsStorage.h
+++ b/Grbl_Esp32/src/SettingsStorage.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  settings.h - eeprom configuration handling
+  SettingsStorage.h - eeprom configuration handling
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/SolenoidPen.cpp
+++ b/Grbl_Esp32/src/SolenoidPen.cpp
@@ -1,5 +1,5 @@
 /*
-  solenoid_pen.cpp
+  SolenoidPen.cpp
   Part of Grbl_ESP32
 
 	copyright (c) 2018 -	Bart Dring This file was modified for use on the ESP32

--- a/Grbl_Esp32/src/SolenoidPen.h
+++ b/Grbl_Esp32/src/SolenoidPen.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  solenoid_pen.h
+  SolenoidPen.h
   Part of Grbl_ESP32
 
 	copyright (c) 2018 -	Bart Dring This file was modified for use on the ESP32

--- a/Grbl_Esp32/src/Spindles/BESCSpindle.h
+++ b/Grbl_Esp32/src/Spindles/BESCSpindle.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-	BESCSpindle.cpp
+	BESCSpindle.h
 
 	This a special type of PWM spindle for RC type Brushless DC Speed
 	controllers. They use a short pulse for off and a longer pulse for

--- a/Grbl_Esp32/src/Spindles/DacSpindle.h
+++ b/Grbl_Esp32/src/Spindles/DacSpindle.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-	DacSpindle.cpp
+	DacSpindle.h
 
 	This uses the Analog DAC in the ESP32 to generate a voltage
 	proportional to the GCode S value desired. Some spindle uses

--- a/Grbl_Esp32/src/Spindles/Spindle.cpp
+++ b/Grbl_Esp32/src/Spindles/Spindle.cpp
@@ -1,5 +1,5 @@
 /*
-    SpindleClass.cpp
+    Spindle.cpp
 
     A Base class for spindles and spinsle like things such as lasers
 

--- a/Grbl_Esp32/src/Spindles/Spindle.h
+++ b/Grbl_Esp32/src/Spindles/Spindle.h
@@ -4,7 +4,7 @@
     Spindle.h
 
     Header file for a Spindle Class
-    See SpindleClass.cpp for more details
+    See Spindle.cpp for more details
 
     Part of Grbl_ESP32
 

--- a/Grbl_Esp32/src/Stepper.cpp
+++ b/Grbl_Esp32/src/Stepper.cpp
@@ -1,5 +1,5 @@
 /*
-  Stepper.c - stepper motor driver: executes motion plans using stepper motors
+  Stepper.cpp - stepper motor driver: executes motion plans using stepper motors
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Stepper.cpp
+++ b/Grbl_Esp32/src/Stepper.cpp
@@ -1,5 +1,5 @@
 /*
-  stepper.c - stepper motor driver: executes motion plans using stepper motors
+  Stepper.c - stepper motor driver: executes motion plans using stepper motors
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/Stepper.h
+++ b/Grbl_Esp32/src/Stepper.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  stepper.h - stepper motor driver: executes motion plans of planner.c using the stepper motors
+  Stepper.h - stepper motor driver: executes motion plans of planner.c using the stepper motors
   Part of Grbl
 
   Copyright (c) 2011-2016 Sungeun K. Jeon for Gnea Research LLC

--- a/Grbl_Esp32/src/System.cpp
+++ b/Grbl_Esp32/src/System.cpp
@@ -1,5 +1,5 @@
 /*
-  system.cpp - Header for system level commands and real-time processes
+  System.cpp - Header for system level commands and real-time processes
   Part of Grbl
   Copyright (c) 2014-2016 Sungeun K. Jeon for Gnea Research LLC
 

--- a/Grbl_Esp32/src/System.h
+++ b/Grbl_Esp32/src/System.h
@@ -21,7 +21,6 @@
 */
 
 #include "Grbl.h"
-#include "TDef.h"
 
 // Define global system variables
 typedef struct {

--- a/Grbl_Esp32/src/TDef.h
+++ b/Grbl_Esp32/src/TDef.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include "Grbl.h"

--- a/Grbl_Esp32/src/WebUI/BTConfig.cpp
+++ b/Grbl_Esp32/src/WebUI/BTConfig.cpp
@@ -1,5 +1,5 @@
 /*
-  BTconfig.cpp -  Bluetooth functions class
+  BTConfig.cpp -  Bluetooth functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/BTConfig.h
+++ b/Grbl_Esp32/src/WebUI/BTConfig.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  BTconfig.h -  Bluetooth functions class
+  BTConfig.h -  Bluetooth functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/Commands.cpp
+++ b/Grbl_Esp32/src/WebUI/Commands.cpp
@@ -1,5 +1,5 @@
 /*
-  commands.cpp - GRBL_ESP command class
+  Commands.cpp - GRBL_ESP command class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/Commands.h
+++ b/Grbl_Esp32/src/WebUI/Commands.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  commands.h - ESP3D configuration class
+  Commands.h - ESP3D configuration class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/ESPResponse.cpp
+++ b/Grbl_Esp32/src/WebUI/ESPResponse.cpp
@@ -1,5 +1,5 @@
 /*
-  espresponse.cpp - GRBL_ESP response class
+  ESPResponse.cpp - GRBL_ESP response class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/ESPResponse.h
+++ b/Grbl_Esp32/src/WebUI/ESPResponse.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  espresponse.h - GRBL_ESP response class
+  ESPResponse.h - GRBL_ESP response class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/InputBuffer.cpp
+++ b/Grbl_Esp32/src/WebUI/InputBuffer.cpp
@@ -1,5 +1,5 @@
 /*
-  inputbuffer.cpp -  inputbuffer functions class
+  InputBuffer.cpp -  inputbuffer functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/InputBuffer.h
+++ b/Grbl_Esp32/src/WebUI/InputBuffer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  inputbuffer.h -  inputbuffer functions class
+  InputBuffer.h -  inputbuffer functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/NoFile.h
+++ b/Grbl_Esp32/src/WebUI/NoFile.h
@@ -2,7 +2,7 @@
 // clang-format off
 
 /*
-  nofile.h - ESP3D data file
+  NoFile.h - ESP3D data file
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/NotificationsService.cpp
+++ b/Grbl_Esp32/src/WebUI/NotificationsService.cpp
@@ -1,5 +1,5 @@
 /*
-  notifications_service.cpp -  notifications service functions class
+  NotificationsService.cpp -  notifications service functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/NotificationsService.h
+++ b/Grbl_Esp32/src/WebUI/NotificationsService.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  notifications_service.h -  notifications service functions class
+  NotificationsService.h -  notifications service functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/Serial2Socket.cpp
+++ b/Grbl_Esp32/src/WebUI/Serial2Socket.cpp
@@ -1,5 +1,5 @@
 /*
-  serial2socket.cpp -  serial 2 socket functions class
+  Serial2Socket.cpp -  serial 2 socket functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/Serial2Socket.h
+++ b/Grbl_Esp32/src/WebUI/Serial2Socket.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  serial2socket.h -  serial 2 socket functions class
+  Serial2Socket.h -  serial 2 socket functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/TelnetServer.cpp
+++ b/Grbl_Esp32/src/WebUI/TelnetServer.cpp
@@ -1,5 +1,5 @@
 /*
-  telnet_server.cpp -  telnet server functions class
+  TelnetServer.cpp -  telnet server functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/TelnetServer.h
+++ b/Grbl_Esp32/src/WebUI/TelnetServer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  telnet_server.h -  telnet service functions class
+  TelnetServer.h -  telnet service functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/WebServer.cpp
+++ b/Grbl_Esp32/src/WebUI/WebServer.cpp
@@ -1,5 +1,5 @@
 /*
-  web_server.cpp -  web server functions class
+  WebServer.cpp -  web server functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/WebServer.h
+++ b/Grbl_Esp32/src/WebUI/WebServer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  web_server.h -  wifi services functions class
+  WebServer.h -  wifi services functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/WifiConfig.cpp
+++ b/Grbl_Esp32/src/WebUI/WifiConfig.cpp
@@ -1,5 +1,5 @@
 /*
-  wificonfig.cpp -  wifi functions class
+  WifiConfig.cpp -  wifi functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/WifiConfig.h
+++ b/Grbl_Esp32/src/WebUI/WifiConfig.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  wificonfig.h -  wifi functions class
+  WifiConfig.h -  wifi functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/WifiServices.cpp
+++ b/Grbl_Esp32/src/WebUI/WifiServices.cpp
@@ -1,5 +1,5 @@
 /*
-  wifiservices.cpp -  wifi services functions class
+  WifiServices.cpp -  wifi services functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 

--- a/Grbl_Esp32/src/WebUI/WifiServices.h
+++ b/Grbl_Esp32/src/WebUI/WifiServices.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
-  wifiservices.h -  wifi services functions class
+  WifiServices.h -  wifi services functions class
 
   Copyright (c) 2014 Luc Lebosse. All rights reserved.
 


### PR DESCRIPTION
The recent rename made nearly all of the
file names included in header comments incorrect.