### PR TITLE
Dynamically changing the mode of I2S

### DIFF
--- a/Grbl_Esp32/src/Config.h
+++ b/Grbl_Esp32/src/Config.h
@@ -88,6 +88,13 @@ Some features should not be changed. See notes below.
 // machine_common.h contains settings that do not change
 #include "MachineCommon.h"
 
+// Adjust exclusive definitions for steppers
+#ifdef USE_I2S_STEPS
+#    ifdef USE_RMT_STEPS
+#        undef USE_RMT_STEPS
+#    endif
+#endif
+
 #define MAX_N_AXIS 6
 
 // Number of axes defined (steppers, servos, etc) (valid range: 3 to 6)

--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -23,7 +23,7 @@
 // Grbl versioning system
 
 #define GRBL_VERSION "1.3a"
-#define GRBL_VERSION_BUILD "20200813"
+#define GRBL_VERSION_BUILD "20200815"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/src/I2SOut.cpp
+++ b/Grbl_Esp32/src/I2SOut.cpp
@@ -55,6 +55,9 @@
 #    include "Pins.h"
 #    include "I2SOut.h"
 
+// Always enable I2S streaming logic
+#    define USE_I2S_OUT_STREAM_IMPL
+
 //
 // Configrations for DMA connected I2S
 //
@@ -75,7 +78,7 @@
 #    define DMA_SAMPLE_COUNT I2S_OUT_DMABUF_LEN / I2S_SAMPLE_SIZE /* number of samples per buffer */
 #    define SAMPLE_SAFE_COUNT (20 / I2S_OUT_USEC_PER_PULSE)       /* prevent buffer overrun (GRBL's $0 should be less than or equal 20) */
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
 typedef struct {
     uint32_t**   buffers;
     uint32_t*    current;
@@ -93,14 +96,28 @@ static atomic_uint_least32_t i2s_out_port_data = ATOMIC_VAR_INIT(0);
 
 // inner lock
 static portMUX_TYPE i2s_out_spinlock = portMUX_INITIALIZER_UNLOCKED;
-#    define I2S_OUT_ENTER_CRITICAL() portENTER_CRITICAL(&i2s_out_spinlock)
-#    define I2S_OUT_EXIT_CRITICAL() portEXIT_CRITICAL(&i2s_out_spinlock)
+#    define I2S_OUT_ENTER_CRITICAL()                                                                                                       \
+        do {                                                                                                                               \
+            if (xPortInIsrContext()) {                                                                                                     \
+                portENTER_CRITICAL_ISR(&i2s_out_spinlock);                                                                                 \
+            } else {                                                                                                                       \
+                portENTER_CRITICAL(&i2s_out_spinlock);                                                                                     \
+            }                                                                                                                              \
+        } while (0)
+#    define I2S_OUT_EXIT_CRITICAL()                                                                                                        \
+        do {                                                                                                                               \
+            if (xPortInIsrContext()) {                                                                                                     \
+                portEXIT_CRITICAL_ISR(&i2s_out_spinlock);                                                                                  \
+            } else {                                                                                                                       \
+                portEXIT_CRITICAL(&i2s_out_spinlock);                                                                                      \
+            }                                                                                                                              \
+        } while (0)
 #    define I2S_OUT_ENTER_CRITICAL_ISR() portENTER_CRITICAL_ISR(&i2s_out_spinlock)
 #    define I2S_OUT_EXIT_CRITICAL_ISR() portEXIT_CRITICAL_ISR(&i2s_out_spinlock)
 
 static int i2s_out_initialized = 0;
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
 static volatile uint64_t             i2s_out_pulse_period;
 static uint64_t                      i2s_out_remain_time_until_next_pulse;  // Time remaining until the next pulse (μsec)
 static volatile i2s_out_pulse_func_t i2s_out_pulse_func;
@@ -110,17 +127,26 @@ static uint8_t i2s_out_ws_pin   = 255;
 static uint8_t i2s_out_bck_pin  = 255;
 static uint8_t i2s_out_data_pin = 255;
 
-enum i2s_out_pulser_status_t {
-    PASSTHROUGH = 0,  // Static I2S mode.The i2s_out_write() reflected with very little delay
-    STEPPING,         // Streaming step data.
-    WAITING,          // Waiting for the step DMA completion
-};
 static volatile i2s_out_pulser_status_t i2s_out_pulser_status = PASSTHROUGH;
 
 // outer lock
 static portMUX_TYPE i2s_out_pulser_spinlock = portMUX_INITIALIZER_UNLOCKED;
-#    define I2S_OUT_PULSER_ENTER_CRITICAL() portENTER_CRITICAL(&i2s_out_pulser_spinlock)
-#    define I2S_OUT_PULSER_EXIT_CRITICAL() portEXIT_CRITICAL(&i2s_out_pulser_spinlock)
+#    define I2S_OUT_PULSER_ENTER_CRITICAL()                                                                                                \
+        do {                                                                                                                               \
+            if (xPortInIsrContext()) {                                                                                                     \
+                portENTER_CRITICAL_ISR(&i2s_out_pulser_spinlock);                                                                          \
+            } else {                                                                                                                       \
+                portENTER_CRITICAL(&i2s_out_pulser_spinlock);                                                                              \
+            }                                                                                                                              \
+        } while (0)
+#    define I2S_OUT_PULSER_EXIT_CRITICAL()                                                                                                 \
+        do {                                                                                                                               \
+            if (xPortInIsrContext()) {                                                                                                     \
+                portEXIT_CRITICAL_ISR(&i2s_out_pulser_spinlock);                                                                           \
+            } else {                                                                                                                       \
+                portEXIT_CRITICAL(&i2s_out_pulser_spinlock);                                                                               \
+            }                                                                                                                              \
+        } while (0)
 #    define I2S_OUT_PULSER_ENTER_CRITICAL_ISR() portENTER_CRITICAL_ISR(&i2s_out_pulser_spinlock)
 #    define I2S_OUT_PULSER_EXIT_CRITICAL_ISR() portEXIT_CRITICAL_ISR(&i2s_out_pulser_spinlock)
 
@@ -159,7 +185,7 @@ static void IRAM_ATTR i2s_out_reset_fifo() {
     I2S_OUT_EXIT_CRITICAL();
 }
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
 static int IRAM_ATTR i2s_clear_dma_buffer(lldesc_t* dma_desc, uint32_t port_data) {
     uint32_t* buf = (uint32_t*)dma_desc->buf;
     for (int i = 0; i < DMA_SAMPLE_COUNT; i++) {
@@ -219,7 +245,7 @@ static int IRAM_ATTR i2s_out_gpio_shiftout(uint32_t port_data) {
 
 static int IRAM_ATTR i2s_out_stop() {
     I2S_OUT_ENTER_CRITICAL();
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     // Stop FIFO DMA
     I2S0.out_link.stop = 1;
 
@@ -245,7 +271,7 @@ static int IRAM_ATTR i2s_out_stop() {
     uint32_t port_data = atomic_load(&i2s_out_port_data);  // current expanded port value
     i2s_out_gpio_shiftout(port_data);
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     //clear pending interrupt
     I2S0.int_clr.val = I2S0.int_st.val;
 #    endif
@@ -268,7 +294,7 @@ static int IRAM_ATTR i2s_out_start() {
     //start DMA link
     i2s_out_reset_fifo_without_lock();
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     if (i2s_out_pulser_status == PASSTHROUGH) {
         I2S0.conf_chan.tx_chan_mod = 3;  // 3:right+constant 4:left+constant (when tx_msb_right = 1)
         I2S0.conf_single_data      = port_data;
@@ -278,7 +304,7 @@ static int IRAM_ATTR i2s_out_start() {
     }
 #    endif
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     //reset DMA
     I2S0.lc_conf.in_rst  = 1;
     I2S0.lc_conf.in_rst  = 0;
@@ -295,7 +321,7 @@ static int IRAM_ATTR i2s_out_start() {
 
     I2S0.conf1.tx_stop_en = 1;  // BCK and WCK are suppressed while FIFO is empty
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     // Connect DMA to FIFO
     I2S0.fifo_conf.dscr_en = 1;  // Set this bit to enable I2S DMA mode. (R/W)
 
@@ -312,7 +338,7 @@ static int IRAM_ATTR i2s_out_start() {
     return 0;
 }
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
 
 static int IRAM_ATTR i2s_fillout_dma_buffer(lldesc_t* dma_desc) {
     uint32_t* buf = (uint32_t*)dma_desc->buf;
@@ -344,7 +370,8 @@ static int IRAM_ATTR i2s_fillout_dma_buffer(lldesc_t* dma_desc) {
                         (*i2s_out_pulse_func)();          // should be pushed into buffer max DMA_SAMPLE_SAFE_COUNT
                         I2S_OUT_PULSER_ENTER_CRITICAL();  // Lock again.
                         // Calculate pulse period. About magic number 2, refer to the st_wake_up(). (Ad hoc delay value)
-                        i2s_out_remain_time_until_next_pulse = i2s_out_pulse_period - I2S_OUT_USEC_PER_PULSE * (o_dma.rw_pos - old_rw_pos) + 2;
+                        i2s_out_remain_time_until_next_pulse =
+                            i2s_out_pulse_period - I2S_OUT_USEC_PER_PULSE * (o_dma.rw_pos - old_rw_pos) + 2;
                         if (i2s_out_pulser_status == WAITING) {
                             // i2s_out_set_passthrough() has called from the pulse function.
                             // It needs to go into pass-through mode.
@@ -497,7 +524,7 @@ static void IRAM_ATTR i2sOutTask(void* parameter) {
 // External funtions
 //
 void IRAM_ATTR i2s_out_delay() {
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     I2S_OUT_PULSER_ENTER_CRITICAL();
     if (i2s_out_pulser_status == PASSTHROUGH) {
         // Depending on the timing, it may not be reflected immediately,
@@ -521,7 +548,7 @@ void IRAM_ATTR i2s_out_write(uint8_t pin, uint8_t val) {
     } else {
         atomic_fetch_and(&i2s_out_port_data, ~bit);
     }
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     // It needs a lock for access, but I've given up because I need speed.
     // This is not a problem as long as there is no overlap between the status change and digitalWrite().
     if (i2s_out_pulser_status == PASSTHROUGH) {
@@ -532,13 +559,13 @@ void IRAM_ATTR i2s_out_write(uint8_t pin, uint8_t val) {
 #    endif
 }
 
-uint8_t IRAM_ATTR i2s_out_state(uint8_t pin) {
+uint8_t IRAM_ATTR i2s_out_read(uint8_t pin) {
     uint32_t port_data = atomic_load(&i2s_out_port_data);
     return (!!(port_data & bit(pin)));
 }
 
 uint32_t IRAM_ATTR i2s_out_push_sample(uint32_t num) {
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     if (num > SAMPLE_SAFE_COUNT) {
         return 0;
     }
@@ -555,9 +582,16 @@ uint32_t IRAM_ATTR i2s_out_push_sample(uint32_t num) {
 #    endif
 }
 
+i2s_out_pulser_status_t IRAM_ATTR i2s_out_get_pulser_status() {
+    I2S_OUT_PULSER_ENTER_CRITICAL();
+    i2s_out_pulser_status_t s = i2s_out_pulser_status;
+    I2S_OUT_PULSER_EXIT_CRITICAL();
+    return s;
+}
+
 int IRAM_ATTR i2s_out_set_passthrough() {
     I2S_OUT_PULSER_ENTER_CRITICAL();
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     if (i2s_out_pulser_status == STEPPING) {
         i2s_out_pulser_status = WAITING;  // Start stopping the pulser
     }
@@ -570,7 +604,7 @@ int IRAM_ATTR i2s_out_set_passthrough() {
 
 int IRAM_ATTR i2s_out_set_stepping() {
     I2S_OUT_PULSER_ENTER_CRITICAL();
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     if (i2s_out_pulser_status == STEPPING) {
         // Re-entered (fail safe)
         I2S_OUT_PULSER_EXIT_CRITICAL();
@@ -613,7 +647,7 @@ int IRAM_ATTR i2s_out_set_stepping() {
 }
 
 int IRAM_ATTR i2s_out_set_pulse_period(uint64_t period) {
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     // Use 64-bit values to avoid overflowing during the calculation.
     i2s_out_pulse_period = period * 1000000 / F_STEPPER_TIMER;
 #    endif
@@ -621,7 +655,7 @@ int IRAM_ATTR i2s_out_set_pulse_period(uint64_t period) {
 }
 
 int IRAM_ATTR i2s_out_set_pulse_callback(i2s_out_pulse_func_t func) {
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     i2s_out_pulse_func = func;
 #    endif
     return 0;
@@ -630,7 +664,7 @@ int IRAM_ATTR i2s_out_set_pulse_callback(i2s_out_pulse_func_t func) {
 int IRAM_ATTR i2s_out_reset() {
     I2S_OUT_PULSER_ENTER_CRITICAL();
     i2s_out_stop();
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     if (i2s_out_pulser_status == STEPPING) {
         uint32_t port_data = atomic_load(&i2s_out_port_data);
         i2s_clear_o_dma_buffers(port_data);
@@ -689,7 +723,7 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
    *      M = 2
    */
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     // Allocate the array of pointers to the buffers
     o_dma.buffers = (uint32_t**)malloc(sizeof(uint32_t*) * I2S_OUT_DMABUF_COUNT);
     if (o_dma.buffers == nullptr)
@@ -757,7 +791,7 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
     I2S0.lc_conf.outdscr_burst_en   = 0;
     I2S0.lc_conf.out_no_restart_clr = 0;
     I2S0.lc_conf.indscr_burst_en    = 0;
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     I2S0.lc_conf.out_eof_mode = 1;  // I2S_OUT_EOF_INT generated when DMA has popped all data from the FIFO;
 #    endif
     I2S0.conf2.lcd_en             = 0;
@@ -767,7 +801,7 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
 
     I2S0.fifo_conf.dscr_en = 0;
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     if (i2s_out_pulser_status == STEPPING) {
         // Stream output mode
         I2S0.conf_chan.tx_chan_mod = 4;  // 3:right+constant 4:left+constant (when tx_msb_right = 1)
@@ -799,7 +833,7 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
     I2S0.conf_chan.rx_chan_mod = 1;  // 1: right+right
     I2S0.conf.rx_mono          = 0;
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     I2S0.fifo_conf.dscr_en = 1;  //connect DMA to fifo
 #    endif
     I2S0.conf.tx_start = 0;
@@ -809,7 +843,7 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
     I2S0.conf.tx_right_first = 0;  // Setting this bit allows the right-channel data to be sent first.
 
     I2S0.conf.tx_slave_mod = 0;  // Master
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     I2S0.fifo_conf.tx_fifo_mod_force_en = 1;  //The bit should always be set to 1.
 #    endif
     I2S0.pdm_conf.rx_pdm_en = 0;  // Set this bit to enable receiver’s PDM mode.
@@ -844,7 +878,7 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
     I2S0.sample_rate_conf.tx_bck_div_num = 2;  // minimum value of 2 defaults to 6
     I2S0.sample_rate_conf.rx_bck_div_num = 2;
 
-#    ifdef USE_I2S_OUT_STREAM
+#    ifdef USE_I2S_OUT_STREAM_IMPL
     // Enable TX interrupts (DMA Interrupts)
     I2S0.int_ena.out_eof       = 1;  // Triggered when rxlink has finished sending a packet.
     I2S0.int_ena.out_dscr_err  = 0;  // Triggered when invalid rxlink descriptors are encountered.

--- a/Grbl_Esp32/src/I2SOut.h
+++ b/Grbl_Esp32/src/I2SOut.h
@@ -41,16 +41,8 @@
 // It should be included at the outset to know the machine configuration.
 #include "Config.h"
 
-// If USE_I2S_OUT_STREAM is defined
-// but the prerequisite USE_I2S_OUT is not defined,
-// it is forced to be defined.
-#ifdef USE_I2S_OUT_STREAM
-#    ifndef USE_I2S_OUT
-#        define USE_I2S_OUT
-#    endif
-#endif
-
 #ifdef USE_I2S_OUT
+
 #    include <stdint.h>
 
 /* Assert */
@@ -119,10 +111,10 @@ int i2s_out_init(i2s_out_init_t& init_param);
 int i2s_out_init();
 
 /*
-  Get a bit state from the internal pin state var.
+  Read a bit state from the internal pin state var.
   pin: expanded pin No. (0..31)
 */
-uint8_t i2s_out_state(uint8_t pin);
+uint8_t i2s_out_read(uint8_t pin);
 
 /*
    Set a bit in the internal pin state var. (not written electrically)
@@ -173,6 +165,16 @@ int i2s_out_set_pulse_period(uint64_t period);
    Register a callback function to generate pulse data
  */
 int i2s_out_set_pulse_callback(i2s_out_pulse_func_t func);
+
+/*
+   Get current pulser mode
+ */
+enum i2s_out_pulser_status_t {
+    PASSTHROUGH = 0,  // Static I2S mode.The i2s_out_write() reflected with very little delay
+    STEPPING,         // Streaming step data.
+    WAITING,          // Waiting for the step DMA completion
+};
+i2s_out_pulser_status_t IRAM_ATTR i2s_out_get_pulser_status();
 
 /*
    Reset i2s I/O expander

--- a/Grbl_Esp32/src/Limits.cpp
+++ b/Grbl_Esp32/src/Limits.cpp
@@ -204,9 +204,11 @@ void limits_go_home(uint8_t cycle_mask) {
                 }
             }
         } while (STEP_MASK & axislock);
-#ifdef USE_I2S_OUT_STREAM
-        if (!approach) {
-            delay_ms(I2S_OUT_DELAY_MS);
+#ifdef USE_I2S_STEPS
+        if (current_stepper == ST_I2S_STREAM) {
+            if (!approach) {
+                delay_ms(I2S_OUT_DELAY_MS);
+            }
         }
 #endif
         st_reset();                        // Immediately force kill steppers and reset step segment buffer.

--- a/Grbl_Esp32/src/Machines/6_pack_MPCNC_stepstick_v1.h
+++ b/Grbl_Esp32/src/Machines/6_pack_MPCNC_stepstick_v1.h
@@ -37,10 +37,8 @@
 
 // I2S (steppers & other output-only pins)
 #define USE_I2S_OUT
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
-#define USE_I2S_OUT_STREAM
-#undef USE_RMT_STEPS
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 
 #define USE_STEPSTICK   // makes sure MS1,2,3 !reset and !sleep are set
 

--- a/Grbl_Esp32/src/Machines/6_pack_stepstick_v1.h
+++ b/Grbl_Esp32/src/Machines/6_pack_stepstick_v1.h
@@ -37,10 +37,8 @@
 
 // I2S (steppers & other output-only pins)
 #define USE_I2S_OUT
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
-//#define USE_I2S_OUT_STREAM
-#undef USE_RMT_STEPS
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 
 #define USE_STEPSTICK   // makes sure MS1,2,3 !reset and !sleep are set
 

--- a/Grbl_Esp32/src/Machines/6_pack_trinamic_V1.h
+++ b/Grbl_Esp32/src/Machines/6_pack_trinamic_V1.h
@@ -30,10 +30,8 @@
 
 // I2S (steppers & other output-only pins)
 #define USE_I2S_OUT
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
-#define USE_I2S_OUT_STREAM
-#undef USE_RMT_STEPS
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 
 #define I2S_OUT_BCK      GPIO_NUM_22
 #define I2S_OUT_WS       GPIO_NUM_17

--- a/Grbl_Esp32/src/Machines/esp32_printer_controller.h
+++ b/Grbl_Esp32/src/Machines/esp32_printer_controller.h
@@ -218,24 +218,16 @@
 #endif
 #define INVERT_CONTROL_PIN_MASK B11111111
 
-// Grbl_ESP32 use the ESP32's special RMT (IR remote control) hardware
-// engine to achieve more precise high step rates than can be done
-// in software.  That feature is enabled by default, but there are
-// some machines that might not want to use it, such as machines that
-// do not use ordinary stepper motors.  To turn it off, do this:
-#undef USE_RMT_STEPS
-
 //
 // I2S (steppers & other output-only pins)
 //
 #define USE_I2S_OUT
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 #define I2S_OUT_BCK      GPIO_NUM_22
 #define I2S_OUT_WS       GPIO_NUM_17
 #define I2S_OUT_DATA     GPIO_NUM_21
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
 #define I2S_OUT_NUM_BITS 16
-#define USE_I2S_OUT_STREAM
 
 // === Special Features
 // Grbl_ESP32 can support non-Cartesian machines and some other

--- a/Grbl_Esp32/src/Machines/i2s_out_xxyyzz.h
+++ b/Grbl_Esp32/src/Machines/i2s_out_xxyyzz.h
@@ -35,10 +35,8 @@
 
 // I2S (steppers & other output-only pins)
 #define USE_I2S_OUT
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
-#define USE_I2S_OUT_STREAM
-#undef USE_RMT_STEPS
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 
 #define USE_STEPSTICK   // makes sure MS1,2,3 !reset and !sleep are set
 

--- a/Grbl_Esp32/src/Machines/i2s_out_xyzabc.h
+++ b/Grbl_Esp32/src/Machines/i2s_out_xyzabc.h
@@ -34,10 +34,8 @@
 
 // I2S (steppers & other output-only pins)
 #define USE_I2S_OUT
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
-#define USE_I2S_OUT_STREAM
-#undef USE_RMT_STEPS
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 
 #define USE_STEPSTICK   // makes sure MS1,2,3 !reset and !sleep are set
 

--- a/Grbl_Esp32/src/Machines/i2s_out_xyzabc_trinamic.h
+++ b/Grbl_Esp32/src/Machines/i2s_out_xyzabc_trinamic.h
@@ -30,10 +30,8 @@
 
 // I2S (steppers & other output-only pins)
 #define USE_I2S_OUT
-// Define USE_I2S_OUT_STREAM if buffering is used.
-// (there will be a delay between the specified I/O operation and the actual I/O execution)
-#define USE_I2S_OUT_STREAM
-#undef USE_RMT_STEPS
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
 
 #define I2S_OUT_BCK      GPIO_NUM_22
 #define I2S_OUT_WS       GPIO_NUM_17

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -479,8 +479,10 @@ void mc_reset() {
         }
         ganged_mode = SQUARING_MODE_DUAL;  // in case an error occurred during squaring
 
-#ifdef USE_I2S_OUT_STREAM
-        i2s_out_reset();
+#ifdef USE_I2S_STEPS
+        if (current_stepper == ST_I2S_STREAM) {
+            i2s_out_reset();
+        }
 #endif
     }
 }

--- a/Grbl_Esp32/src/Pins.cpp
+++ b/Grbl_Esp32/src/Pins.cpp
@@ -48,7 +48,7 @@ int IRAM_ATTR digitalRead(uint8_t pin) {
         return __digitalRead(pin);
     }
 #ifdef USE_I2S_OUT
-    return i2s_out_state(pin - I2S_OUT_PIN_BASE);
+    return i2s_out_read(pin - I2S_OUT_PIN_BASE);
 #else
     return 0;
 #endif

--- a/Grbl_Esp32/src/ProcessSettings.cpp
+++ b/Grbl_Esp32/src/ProcessSettings.cpp
@@ -207,7 +207,20 @@ err_t home(int cycle) {
     if (system_check_safety_door_ajar())
         return (STATUS_CHECK_DOOR);  // Block if safety door is ajar.
     sys.state = STATE_HOMING;        // Set system state variable
+#ifdef USE_I2S_STEPS
+    stepper_id_t save_stepper = current_stepper;
+    if (save_stepper == ST_I2S_STREAM) {
+        stepper_switch(ST_I2S_STATIC);
+    }
+
     mc_homing_cycle(cycle);
+
+    if (save_stepper == ST_I2S_STREAM && current_stepper != ST_I2S_STREAM) {
+        stepper_switch(ST_I2S_STREAM);
+    }
+#else
+    mc_homing_cycle(cycle);
+#endif
     if (!sys.abort) {            // Execute startup scripts after successful homing.
         sys.state = STATE_IDLE;  // Set to IDLE when complete.
         st_go_idle();            // Set steppers to the settings idle state before returning.

--- a/Grbl_Esp32/src/Stepper.cpp
+++ b/Grbl_Esp32/src/Stepper.cpp
@@ -414,9 +414,7 @@ static void stepper_pulse_func() {
             segment_buffer_tail = 0;
     }
 
-#ifdef USE_RMT_STEPS
-    return;
-#elif defined(USE_I2S_STEPS)
+#ifdef USE_I2S_STEPS
     if (current_stepper == ST_I2S_STREAM) {
         //
         // Generate pulse (at least one pulse)
@@ -427,6 +425,9 @@ static void stepper_pulse_func() {
         set_stepper_pins_on(0);  // turn all off
         return;
     }
+#endif
+#ifdef USE_RMT_STEPS
+    return;
 #else
     st.step_outbits ^= step_port_invert_mask;  // Apply step port invert mask
     // wait for step pulse time to complete...some of it should have expired during code above

--- a/Grbl_Esp32/src/Stepper.h
+++ b/Grbl_Esp32/src/Stepper.h
@@ -75,11 +75,21 @@ extern bool         stepper_idle;
 
 extern uint8_t ganged_mode;
 
+enum stepper_id_t {
+    ST_TIMED = 0,
+    ST_RMT,
+    ST_I2S_STREAM,
+    ST_I2S_STATIC,
+};
+extern const char*  stepper_names[];
+extern stepper_id_t current_stepper;
+
 // -- Task handles for use in the notifications
 void IRAM_ATTR onSteppertimer();
 void IRAM_ATTR onStepperOffTimer();
 
 void stepper_init();
+void stepper_switch(stepper_id_t new_stepper);
 
 // Enable steppers, but cycle does not start unless called by motion control or realtime command.
 void st_wake_up();
@@ -115,5 +125,6 @@ void set_stepper_pins_on(uint8_t onMask);
 void set_direction_pins_on(uint8_t onMask);
 
 void Stepper_Timer_WritePeriod(uint64_t alarm_val);
+void Stepper_Timer_Init();
 void Stepper_Timer_Start();
 void Stepper_Timer_Stop();


### PR DESCRIPTION
The I2S stepper has two modes.
- I2S static Mode
  Short (4-8 μsec) delay, little jitter
- I2S stream mode
  Long (10-12 millisec) delay, no jitter

This PR is a proposed change that takes advantage of the strengths of each mode of I2S and uses them to their advantage.

In homing and probing, synchronization of sensor input and motor movement is important. So be sure to use the I2S static mode.
Normal motor movement can generate perfectly precalculated steps in normal motor movement, so use the I2S stream mode for accurate movement. 
However, it is now possible to fix it to I2S static mode in the machine configuration.
`#define DEFAULT_STEPPER ST_I2S_STATIC`

In my environment, it appears to be working as intended.

Please confirm.

```
ets Jun  8 2016 00:22:57

rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DIO, clock div:1
load:0x3fff0018,len:4
load:0x3fff001c,len:1216
ho 0 tail 12 room 4
load:0x40078000,len:9720
ho 0 tail 12 room 4
load:0x40080400,len:6352
entry 0x400806b8

[MSG:Grbl_ESP32 Ver 1.3a Date 20200815]
[MSG:Compiled with ESP32 SDK:v3.2.3-14-gd3e562907]
[MSG:Using machine:ESP32 SPI 6 Axis Driver Board Trinamic Test]
[MSG:Axis count 6]
[MSG:I2S Steps, Stream]
[MSG:Init Motors]
[MSG:X  Axis Trinamic TMC2130 Step:I2SO(2) Dir:I2SO(1) CS:I2SO(3) Disable:I2SO(0) Index:-1]
[MSG:Y  Axis Trinamic TMC2130 Step:I2SO(5) Dir:I2SO(4) CS:I2SO(6) Disable:I2SO(7) Index:-1]
[MSG:Z  Axis Trinamic TMC2130 Step:I2SO(10) Dir:I2SO(9) CS:I2SO(11) Disable:I2SO(8) Index:-1]
[MSG:A  Axis Trinamic TMC2130 Step:I2SO(13) Dir:I2SO(12) CS:I2SO(14) Disable:I2SO(15) Index:-1]
[MSG:B  Axis Trinamic TMC2130 Step:I2SO(18) Dir:I2SO(17) CS:I2SO(19) Disable:I2SO(16) Index:-1]
[MSG:C  Axis Trinamic TMC2130 Step:I2SO(21) Dir:I2SO(20) CS:I2SO(22) Disable:I2SO(23) Index:-1]
[MSG:X  Trinamic driver test passed]
[MSG:Y  Trinamic driver test passed]
[MSG:Z  Trinamic driver test passed]
[MSG:A  Trinamic driver test passed]
[MSG:B  Trinamic driver test passed]
[MSG:C  Trinamic driver test passed]
[MSG:TMCStepper Library Ver. 0x000701]
[MSG:Relay spindle Output:GPIO(26), Enbl:None, Dir:None]

[MSG:Local access point GRBL_ESP started, 192.168.0.1]
[MSG:Captive Portal Started]
[MSG:HTTP Started]
[MSG:TELNET Started 23]
[MSG:Probe on pin GPIO(25) Inverted:Y]

Grbl 1.3a ['$' for help]
[MSG:'$H'|'$X' to unlock]
$H
ok
ok
g38.2 x10 f50
[PRB:-0.011,0.000,0.000,0.000,0.000,0.000:1]
ok
ok
g0x-3
ok
ok
g38.2 x10 f50
[PRB:-0.011,0.000,0.000,0.000,0.000,0.000:1]
ok
ok
g0x-3
ok
ok
g38.2 x10 f50
[PRB:-0.011,0.000,0.000,0.000,0.000,0.000:1]
ok
ok
$S
$Sta/SSID=GRBL_ESP
$Sta/Password=******
$Sta/IPMode=DHCP
$Sta/IP=0.0.0.0
$Sta/Gateway=0.0.0.0
$Sta/Netmask=0.0.0.0
$AP/SSID=GRBL_ESP
$AP/Password=******
$AP/IP=192.168.0.1
$AP/Channel=1
$System/Hostname=grblesp
$Http/Enable=ON
$Http/Port=80
$Telnet/Enable=ON
$Telnet/Port=23
$Radio/Mode=AP
$Bluetooth/Name=btgrblesp
$Notification/Type=NONE
$Notification/T1=
$Notification/T2=
$Notification/TS=
$Report/StallGuard=
$Spindle/Type=RELAY
$Stepper/Pulse=4
$Stepper/IdleTime=250
$Stepper/StepInvert=
$Stepper/DirInvert=Y
$Stepper/EnableInvert=Off
$Limits/Invert=On
$Probe/Invert=On
$Report/Status=1
$GCode/JunctionDeviation=0.010
$GCode/ArcTolerance=0.002
$Report/Inches=Off
$Limits/Soft=Off
$Limits/Hard=Off
$Homing/Enable=On
$Homing/DirInvert=
$Homing/Feed=200.000
$Homing/Seek=1000.000
$Homing/Debounce=250.000
$Homing/Pulloff=3.000
$GCode/MaxS=1000.000
$GCode/MinS=0.000
$GCode/LaserMode=Off
$GCode/Line1=
$GCode/Line0=
$Spindle/Enable/Invert=Off
$Spindle/Enable/OffWithSpeed=Off
$Spindle/Delay/SpinDown=0.000
$Spindle/Delay/SpinUp=0.000
$Spindle/PWM/Invert=Off
$Spindle/PWM/Frequency=5000.000
$Spindle/PWM/Off=0.000
$Spindle/PWM/Min=0.000
$Spindle/PWM/Max=100.000
$X/StepsPerMm=88.889
$Y/StepsPerMm=77.037
$Z/StepsPerMm=100.000
$A/StepsPerMm=100.000
$B/StepsPerMm=100.000
$C/StepsPerMm=100.000
$X/MaxRate=5000.000
$Y/MaxRate=15000.000
$Z/MaxRate=3000.000
$A/MaxRate=1000.000
$B/MaxRate=1000.000
$C/MaxRate=1000.000
$X/Acceleration=200.000
$Y/Acceleration=200.000
$Z/Acceleration=50.000
$A/Acceleration=200.000
$B/Acceleration=200.000
$C/Acceleration=200.000
$X/MaxTravel=50.000
$Y/MaxTravel=300.000
$Z/MaxTravel=100.000
$A/MaxTravel=300.000
$B/MaxTravel=300.000
$C/MaxTravel=300.000
$X/Current/Run=0.250
$Y/Current/Run=0.250
$Z/Current/Run=0.250
$A/Current/Run=0.250
$B/Current/Run=0.250
$C/Current/Run=0.250
$X/Current/Hold=0.125
$Y/Current/Hold=0.125
$Z/Current/Hold=0.125
$A/Current/Hold=0.125
$B/Current/Hold=0.125
$C/Current/Hold=0.125
$X/Microsteps=16
$Y/Microsteps=16
$Z/Microsteps=16
$A/Microsteps=16
$B/Microsteps=16
$C/Microsteps=16
$X/StallGuard=16
$Y/StallGuard=16
$Z/StallGuard=16
$A/StallGuard=16
$B/StallGuard=16
$C/StallGuard=16
ok
ok
```