### PR TITLE
Fix configurator

### DIFF
--- a/configure-features.py
+++ b/configure-features.py
@@ -3,7 +3,7 @@
 #
 # Grbl_Esp32 configurator
 #   Copyright (C) 2020 Michiyasu Odaki
-# 
+#
 # This is useful for automated testing, to make sure you haven't broken something
 #
 #  Grbl_Esp32 is free software: you can redistribute it and/or modify
@@ -23,7 +23,7 @@ from __future__ import print_function
 import os, sys, argparse, re
 
 configDirName = r'Grbl_Esp32'
-configFileName = r'config.h'
+configFileName = r'Config.h'
 
 validFeatureList = [
     'BLUETOOTH',
@@ -88,7 +88,7 @@ def checkFeatureList(optname, features, verbose=False):
                 return -1
     else:
         #if verbose:
-        #    print(optname + " is not specified")  
+        #    print(optname + " is not specified")
         return 0
 
     return len(features)

--- a/configure-features.py
+++ b/configure-features.py
@@ -22,7 +22,7 @@
 from __future__ import print_function
 import os, sys, argparse, re
 
-configDirName = r'Grbl_Esp32'
+configDirName = r'Grbl_Esp32/src'
 configFileName = r'Config.h'
 
 validFeatureList = [


### PR DESCRIPTION
Travis CI fails.
This is because the file path in configure-feature.py that I wrote for Travis CI was not able to support the latest source tree.
I've created a small PR, please merge it.