### PR TITLE
Fix #580 Coolant overrides

### DIFF
--- a/Grbl_Esp32/src/CoolantControl.cpp
+++ b/Grbl_Esp32/src/CoolantControl.cpp
@@ -34,87 +34,84 @@ void coolant_init() {
 }
 
 // Returns current coolant output state. Overrides may alter it from programmed state.
-CoolantMode coolant_get_state() {
-    CoolantMode cl_state = {};
+CoolantState coolant_get_state() {
+    CoolantState cl_state = {};
+    bool pinState;
+
 #ifdef COOLANT_FLOOD_PIN
+    pinState = digitalRead(COOLANT_FLOOD_PIN);
 #    ifdef INVERT_COOLANT_FLOOD_PIN
-    if (!digitalRead(COOLANT_FLOOD_PIN)) {
-#    else
-    if (digitalRead(COOLANT_FLOOD_PIN)) {
+    pinState = !pinState;
 #    endif
+    if (pinState) {
         cl_state.Flood = 1;
     }
 #endif
+
 #ifdef COOLANT_MIST_PIN
+    pinState = digitalRead(COOLANT_MIST_PIN);
 #    ifdef INVERT_COOLANT_MIST_PIN
-    if (!digitalRead(COOLANT_MIST_PIN)) {
-#    else
-    if (digitalRead(COOLANT_MIST_PIN)) {
+    pinState = !pinState;
 #    endif
+    if (pinState) {
         cl_state.Mist = 1;
     }
 #endif
+
     return cl_state;
+}
+
+static inline void coolant_write(CoolantState state) {
+    bool pinState;
+
+#ifdef COOLANT_FLOOD_PIN
+    pinState = state.Flood;
+#    ifdef INVERT_COOLANT_FLOOD_PIN
+    pinState = !pinState;
+#    endif
+    digitalWrite(COOLANT_FLOOD_PIN, pinState);
+#endif
+
+#ifdef COOLANT_MIST_PIN
+    pinState = state.Mist;
+#    ifdef INVERT_COOLANT_MIST_PIN
+    pinState = !pinState;
+#    endif
+    digitalWrite(COOLANT_MIST_PIN, pinState);
+#endif
 }
 
 // Directly called by coolant_init(), coolant_set_state(), and mc_reset(), which can be at
 // an interrupt-level. No report flag set, but only called by routines that don't need it.
 void coolant_stop() {
-#ifdef COOLANT_FLOOD_PIN
-#    ifdef INVERT_COOLANT_FLOOD_PIN
-    digitalWrite(COOLANT_FLOOD_PIN, 1);
-#    else
-    digitalWrite(COOLANT_FLOOD_PIN, 0);
-#    endif
-#endif
-#ifdef COOLANT_MIST_PIN
-#    ifdef INVERT_COOLANT_MIST_PIN
-    digitalWrite(COOLANT_MIST_PIN, 1);
-#    else
-    digitalWrite(COOLANT_MIST_PIN, 0);
-#    endif
-#endif
+    CoolantState disable = {};
+    coolant_write(disable);
 }
 
 // Main program only. Immediately sets flood coolant running state and also mist coolant,
 // if enabled. Also sets a flag to report an update to a coolant state.
 // Called by coolant toggle override, parking restore, parking retract, sleep mode, g-code
 // parser program end, and g-code parser coolant_sync().
-void coolant_set_state(CoolantMode mode) {
+
+void coolant_set_state(CoolantState state) {
     if (sys.abort) {
         return;  // Block during abort.
     }
-    if (mode.IsDisabled()) {
-        coolant_stop();
-    } else {
-#ifdef COOLANT_FLOOD_PIN
-        if (mode.Flood) {
-#    ifdef INVERT_COOLANT_FLOOD_PIN
-            digitalWrite(COOLANT_FLOOD_PIN, 0);
-#    else
-            digitalWrite(COOLANT_FLOOD_PIN, 1);
-#    endif
-        }
-#endif
-#ifdef COOLANT_MIST_PIN
-        if (mode.Mist) {
-#    ifdef INVERT_COOLANT_MIST_PIN
-            digitalWrite(COOLANT_MIST_PIN, 0);
-#    else
-            digitalWrite(COOLANT_MIST_PIN, 1);
-#    endif
-        }
-#endif
-    }
+    coolant_write(state);
     sys.report_ovr_counter = 0;  // Set to report change immediately
+}
+
+void coolant_off() {
+    CoolantState disable = {};
+    coolant_set_state(disable);
 }
 
 // G-code parser entry-point for setting coolant state. Forces a planner buffer sync and bails
 // if an abort or check-mode is active.
-void coolant_sync(CoolantMode mode) {
+void coolant_sync(CoolantState state) {
     if (sys.state == STATE_CHECK_MODE) {
         return;
     }
     protocol_buffer_synchronize();  // Ensure coolant turns on when specified in program.
-    coolant_set_state(mode);
+    coolant_set_state(state);
 }

--- a/Grbl_Esp32/src/CoolantControl.h
+++ b/Grbl_Esp32/src/CoolantControl.h
@@ -27,13 +27,14 @@
 void coolant_init();
 
 // Returns current coolant output state. Overrides may alter it from programmed state.
-CoolantMode coolant_get_state();
+CoolantState coolant_get_state();
 
 // Immediately disables coolant pins.
 void coolant_stop();
 
 // Sets the coolant pins according to state specified.
-void coolant_set_state(CoolantMode mode);
+void coolant_off();
+void coolant_set_state(CoolantState state);
 
 // G-code parser entry-point for setting coolant states. Checks for and executes additional conditions.
-void coolant_sync(CoolantMode mode);
+void coolant_sync(CoolantState state);

--- a/Grbl_Esp32/src/GCode.cpp
+++ b/Grbl_Esp32/src/GCode.cpp
@@ -454,17 +454,17 @@ uint8_t gc_execute_line(char* line, uint8_t client) {
                         switch (int_value) {
 #ifdef COOLANT_MIST_PIN
                             case 7:
-                                gc_block.modal.coolant      = {};
-                                gc_block.modal.coolant.Mist = 1;
+                                gc_block.coolant = GCodeCoolant::M7;
                                 break;
 #endif
 #ifdef COOLANT_FLOOD_PIN
                             case 8:
-                                gc_block.modal.coolant       = {};
-                                gc_block.modal.coolant.Flood = 1;
+                                gc_block.coolant = GCodeCoolant::M8;
                                 break;
 #endif
-                            case 9: gc_block.modal.coolant = {}; break;
+                            case 9:
+                                gc_block.coolant = GCodeCoolant::M9;
+                                break;
                         }
                         mg_word_bit = ModalGroup::MM8;
                         break;
@@ -1270,15 +1270,25 @@ uint8_t gc_execute_line(char* line, uint8_t client) {
     }
     pl_data->spindle = gc_state.modal.spindle;
     // [8. Coolant control ]:
-    if (gc_state.modal.coolant != gc_block.modal.coolant) {
-        // NOTE: Coolant M-codes are modal. Only one command per line is allowed. But, multiple states
-        // can exist at the same time, while coolant disable clears all states.
-        coolant_sync(gc_block.modal.coolant);
-        if (gc_block.modal.coolant.IsDisabled()) {
+    // At most one of M7, M8, M9 can appear in a GCode block, but the overall coolant
+    // state can have both mist (M7) and flood (M8) on at once, by issuing M7 and M8
+    // in separate blocks.  There is no GCode way to turn them off separately, but
+    // you can turn them off simultaneously with M9.  You can turn them off separately
+    // with real-time overrides, but that is out of the scope of GCode.
+    switch (gc_block.coolant) {
+        case GCodeCoolant::None: break;
+        case GCodeCoolant::M7:
+            gc_state.modal.coolant.Mist = 1;
+            coolant_sync(gc_state.modal.coolant);
+            break;
+        case GCodeCoolant::M8:
+            gc_state.modal.coolant.Flood = 1;
+            coolant_sync(gc_state.modal.coolant);
+            break;
+        case GCodeCoolant::M9:
             gc_state.modal.coolant = {};
-        } else {
-            gc_state.modal.coolant = CoolantMode(gc_state.modal.coolant, gc_block.modal.coolant);
-        }
+            coolant_sync(gc_state.modal.coolant);
+            break;
     }
     pl_data->coolant = gc_state.modal.coolant;  // Set state for planner use.
     // turn on/off an i/o pin
@@ -1474,7 +1484,7 @@ uint8_t gc_execute_line(char* line, uint8_t client) {
                 }
                 system_flag_wco_change();  // Set to refresh immediately just in case something altered.
                 spindle->set_state(SpindleState::Disable, 0);
-                coolant_set_state(CoolantMode());
+                coolant_off();
             }
             report_feedback_message(MESSAGE_PROGRAM_END);
 #ifdef USE_M30

--- a/Grbl_Esp32/src/Planner.h
+++ b/Grbl_Esp32/src/Planner.h
@@ -55,7 +55,7 @@ typedef struct {
     // Block condition data to ensure correct execution depending on states and overrides.
     uint8_t      motion;   // Block bitflag motion conditions. Copied from pl_line_data.
     SpindleState spindle;  // Spindle enable state
-    CoolantMode  coolant;  // Coolant state
+    CoolantState coolant;  // Coolant state
 #ifdef USE_LINE_NUMBERS
     int32_t line_number;  // Block line number for real-time reporting. Copied from pl_line_data.
 #endif
@@ -85,7 +85,7 @@ typedef struct {
     uint32_t     spindle_speed;  // Desired spindle speed through line motion.
     uint8_t      motion;         // Bitflag variable to indicate motion conditions. See defines above.
     SpindleState spindle;        // Spindle enable state
-    CoolantMode  coolant;        // Coolant state
+    CoolantState coolant;        // Coolant state
 #ifdef USE_LINE_NUMBERS
     int32_t line_number;  // Desired line number to report when executing.
 #endif

--- a/Grbl_Esp32/src/Report.cpp
+++ b/Grbl_Esp32/src/Report.cpp
@@ -417,19 +417,18 @@ void report_gcode_modes(uint8_t client) {
     strcat(modes_rpt, mode);
 
     //report_util_gcode_modes_M();  // optional M7 and M8 should have been dealt with by here
-    if (gc_state.modal.coolant.IsDisabled()) {
-        mode = " M9";
+    auto coolant = gc_state.modal.coolant;
+    if (!coolant.Mist && !coolant.Flood) {
+        strcat(modes_rpt, " M9");
     } else {
-        auto coolant = gc_state.modal.coolant;
         // Note: Multiple coolant states may be active at the same time.
         if (coolant.Mist) {
-            mode = " M7";
+            strcat(modes_rpt, " M7");
         }
         if (coolant.Flood) {
-            mode = " M8";
+            strcat(modes_rpt, " M8");
         }
     }
-    strcat(modes_rpt, mode);
 
 #ifdef ENABLE_PARKING_OVERRIDE_CONTROL
     if (sys.override_ctrl == OVERRIDE_PARKING_MOTION) {
@@ -736,8 +735,8 @@ void report_realtime_status(uint8_t client) {
         sprintf(temp, "|Ov:%d,%d,%d", sys.f_override, sys.r_override, sys.spindle_speed_ovr);
         strcat(status, temp);
         SpindleState sp_state      = spindle->get_state();
-        CoolantMode  coolant_state = coolant_get_state();
-        if (sp_state != SpindleState::Disable || !coolant_state.IsDisabled()) {
+        CoolantState coolant_state = coolant_get_state();
+        if (sp_state != SpindleState::Disable || coolant_state.Mist || coolant_state.Flood) {
             strcat(status, "|A:");
             switch (sp_state) {
                 case SpindleState::Disable: break;


### PR DESCRIPTION
The approach was

a) Split up the CoolantMode enum, which had become complicated because
   it was trying to solve two incompatible requirements, into two
   enums GCodeCoolant (a pure enumeration for the use of the GCode
   parser) and CoolantState (a bitfield for runtime use where
   independent turn-off is possible via overrides)

b) Fixed coolant_set_state() so it can turn off coolant bits
   independently.  Previously it could turn them on independently,
   but only turn them off simultaneously.  That was fine for M7 M8 M9,
   but inadequate for realtime coolant overrides.

c) In the process, I refactored the code in CoolantControl.cpp with
   the goal of "saying things once", thus reducing the number of
   ifdefs.  When we have the Pin class, the ifdefs will be reduced
   even more, perhaps even eliminated.  Meanwhile, this cleans up the
   code and probably makes the transition to Pins easier.

d) I also fixed a bug in Report.cpp in which it was not possible to
   report both M7 and M8 at the same time.