### PR TITLE
Use local libs with pio

### DIFF
--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -23,7 +23,7 @@
 // Grbl versioning system
 
 #define GRBL_VERSION "1.3a"
-#define GRBL_VERSION_BUILD "20200831"
+#define GRBL_VERSION_BUILD "20200908"
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,7 @@ build_flags =
 
 [env]
 lib_deps =
-	TMCStepper@>=0.7.0
+	TMCStepper@>=0.7.0,<1.0.0
 platform = espressif32
 board = esp32dev
 framework = arduino

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,8 +32,6 @@ build_flags =
 [env]
 lib_deps =
 	TMCStepper@>=0.7.0
-	arduinoWebSockets
-	ESP32SSPD
 platform = espressif32
 board = esp32dev
 framework = arduino


### PR DESCRIPTION
When building with PlatfomIO, the local libraries are no longer being used.
As for ArduinoWebsockets, another library of the same name is used, unintentionally.
https://platformio.org/lib/show/6149/ArduinoWebsockets
Originally, the local version 2.1.2 should have been used, but the version 0.4.18, which should not exist, is used.
```
> Executing task: platformio run <
Processing release (platform: espressif32; board: esp32dev; framework: arduino)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32dev.html
PLATFORM: Espressif 32 (2.0.0) > Espressif ESP32 Dev Module
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (esp-prog) External (esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-arduinoespressif32 3.10004.200129 (1.0.4) 
 - tool-esptoolpy 1.20600.0 (2.6.0) 
 - toolchain-xtensa32 2.50200.80 (5.2.0)
Converting Grbl_Esp32.ino
LDF: Library Dependency Finder -> http://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 30 compatible libraries
Scanning dependencies...
Dependency Graph
|-- <TMCStepper> 0.7.1
|   |-- <SPI> 1.0
|-- <ArduinoWebsockets> 0.4.18
|   |-- <WiFi> 1.0
|-- <ESP32SSPD> 1.0
|   |-- <WiFi> 1.0
:
```
To fix this problem, please change the lib_deps in platformio.ini.

The modified version uses the local library as intended.
```
> Executing task: platformio run <

Processing release (platform: espressif32; board: esp32dev; framework: arduino)
-------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32dev.html
PLATFORM: Espressif 32 (2.0.0) > Espressif ESP32 Dev Module
HARDWARE: ESP32 240MHz, 320KB RAM, 4MB Flash
DEBUG: Current (esp-prog) External (esp-prog, iot-bus-jtag, jlink, minimodule, olimex-arm-usb-ocd, olimex-arm-usb-ocd-h, olimex-arm-usb-tiny-h, olimex-jtag-tiny, tumpa)
PACKAGES: 
 - framework-arduinoespressif32 3.10004.200129 (1.0.4) 
 - tool-esptoolpy 1.20600.0 (2.6.0) 
 - toolchain-xtensa32 2.50200.80 (5.2.0)
Converting Grbl_Esp32.ino
LDF: Library Dependency Finder -> http://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 30 compatible libraries
Scanning dependencies...
Dependency Graph
|-- <TMCStepper> 0.7.1
|   |-- <SPI> 1.0
|-- <WiFi> 1.0
|-- <EEPROM> 1.0.3
|-- <Preferences> 1.0
|-- <ESP32 BLE Arduino> 1.0.1
|-- <FS> 1.0
|-- <SD(esp32)> 1.0.5
|   |-- <FS> 1.0
|   |-- <SPI> 1.0
|-- <SPI> 1.0
|-- <BluetoothSerial> 1.0
|-- <WebServer> 1.0
|   |-- <WiFi> 1.0
|   |-- <FS> 1.0
|-- <WiFiClientSecure> 1.0
|   |-- <WiFi> 1.0
|-- <WebSockets> 2.1.2
|   |-- <SPI> 1.0
|   |-- <WiFi> 1.0
|   |-- <WiFiClientSecure> 1.0
|   |   |-- <WiFi> 1.0
|-- <DNSServer> 1.1.0
|   |-- <WiFi> 1.0
|-- <ESP32SSPD> 1.0
|   |-- <WiFi> 1.0
|-- <ESPmDNS> 1.0
|   |-- <WiFi> 1.0
|-- <SPIFFS> 1.0
|   |-- <FS> 1.0
|-- <Update> 1.0
|-- <ArduinoOTA> 1.0
|   |-- <Update> 1.0
|   |-- <WiFi> 1.0
|   |-- <ESPmDNS> 1.0
|   |   |-- <WiFi> 1.0
Building in release mode
Compiling .pio/build/release/src/Grbl_Esp32.ino.cpp.o
Compiling .pio/build/release/src/src/CoolantControl.cpp.o
Compiling .pio/build/release/src/src/CustomCode.cpp.o
Compiling .pio/build/release/src/src/Eeprom.cpp.o
Compiling .pio/build/release/src/src/GCode.cpp.o
Compiling .pio/build/release/src/src/Grbl.cpp.o
Compiling .pio/build/release/src/src/I2SOut.cpp.o
Compiling .pio/build/release/src/src/Jog.cpp.o
Compiling .pio/build/release/src/src/Limits.cpp.o
Compiling .pio/build/release/src/src/MotionControl.cpp.o
Compiling .pio/build/release/src/src/Motors/Motor.cpp.o
Compiling .pio/build/release/src/src/Motors/Motors.cpp.o
Compiling .pio/build/release/src/src/Motors/RcServo.cpp.o
Compiling .pio/build/release/src/src/Motors/StandardStepper.cpp.o
Compiling .pio/build/release/src/src/Motors/TrinamicDriver.cpp.o
Compiling .pio/build/release/src/src/Motors/UnipolarMotor.cpp.o
Compiling .pio/build/release/src/src/NutsBolts.cpp.o
Compiling .pio/build/release/src/src/Pins.cpp.o
Compiling .pio/build/release/src/src/Planner.cpp.o
Compiling .pio/build/release/src/src/Probe.cpp.o
Compiling .pio/build/release/src/src/ProcessSettings.cpp.o
Compiling .pio/build/release/src/src/Protocol.cpp.o
Compiling .pio/build/release/src/src/Report.cpp.o
Compiling .pio/build/release/src/src/SDCard.cpp.o
Compiling .pio/build/release/src/src/Serial.cpp.o
Compiling .pio/build/release/src/src/Settings.cpp.o
Compiling .pio/build/release/src/src/SettingsDefinitions.cpp.o
Compiling .pio/build/release/src/src/SettingsStorage.cpp.o
Compiling .pio/build/release/src/src/Spindles/10vSpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/BESCSpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/DacSpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/H2ASpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/HuanyangSpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/Laser.cpp.o
Compiling .pio/build/release/src/src/Spindles/NullSpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/PWMSpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/RelaySpindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/Spindle.cpp.o
Compiling .pio/build/release/src/src/Spindles/VFDSpindle.cpp.o
Compiling .pio/build/release/src/src/Stepper.cpp.o
Compiling .pio/build/release/src/src/System.cpp.o
Compiling .pio/build/release/src/src/WebUI/Authentication.cpp.o
Compiling .pio/build/release/src/src/WebUI/BTConfig.cpp.o
Compiling .pio/build/release/src/src/WebUI/Commands.cpp.o
Compiling .pio/build/release/src/src/WebUI/ESPResponse.cpp.o
Compiling .pio/build/release/src/src/WebUI/InputBuffer.cpp.o
Compiling .pio/build/release/src/src/WebUI/JSONEncoder.cpp.o
Compiling .pio/build/release/src/src/WebUI/NotificationsService.cpp.o
Compiling .pio/build/release/src/src/WebUI/Serial2Socket.cpp.o
Compiling .pio/build/release/src/src/WebUI/TelnetServer.cpp.o
Compiling .pio/build/release/src/src/WebUI/WebServer.cpp.o
Compiling .pio/build/release/src/src/WebUI/WebSettings.cpp.o
Compiling .pio/build/release/src/src/WebUI/WifiConfig.cpp.o
Compiling .pio/build/release/src/src/WebUI/WifiServices.cpp.o
Generating partitions .pio/build/release/partitions.bin
Compiling .pio/build/release/libb0a/SPI/SPI.cpp.o
Archiving .pio/build/release/libb0a/libSPI.a
Indexing .pio/build/release/libb0a/libSPI.a
Compiling .pio/build/release/libb56/TMCStepper/source/CHOPCONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/COOLCONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/DRVCONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/DRVCTRL.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/DRVSTATUS.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/DRV_CONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/DRV_STATUS.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/ENCMODE.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/GCONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/IHOLD_IRUN.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/PWMCONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/RAMP_STAT.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/SERIAL_SWITCH.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/SGCSCONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/SHORT_CONF.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/SMARTEN.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/SW_MODE.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/SW_SPI.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC2130Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC2160Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC2208Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC2209Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC2660Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC5130Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMC5160Stepper.cpp.o
Compiling .pio/build/release/libb56/TMCStepper/source/TMCStepper.cpp.o
Compiling .pio/build/release/lib37b/WiFi/ETH.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFi.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiAP.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiClient.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiGeneric.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiMulti.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiSTA.cpp.o
Archiving .pio/build/release/libb56/libTMCStepper.a
Indexing .pio/build/release/libb56/libTMCStepper.a
Compiling .pio/build/release/lib37b/WiFi/WiFiScan.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiServer.cpp.o
Compiling .pio/build/release/lib37b/WiFi/WiFiUdp.cpp.o
Compiling .pio/build/release/lib664/EEPROM/EEPROM.cpp.o
Compiling .pio/build/release/lib43c/Preferences/Preferences.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLE2902.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLE2904.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEAddress.cpp.o
Archiving .pio/build/release/lib37b/libWiFi.a
Compiling .pio/build/release/libdc4/BLE/BLEAdvertisedDevice.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEAdvertising.cpp.o
Indexing .pio/build/release/lib37b/libWiFi.a
Compiling .pio/build/release/libdc4/BLE/BLEBeacon.cpp.o
Archiving .pio/build/release/lib664/libEEPROM.a
Indexing .pio/build/release/lib664/libEEPROM.a
Compiling .pio/build/release/libdc4/BLE/BLECharacteristic.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLECharacteristicMap.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEClient.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEDescriptor.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEDescriptorMap.cpp.o
Archiving .pio/build/release/lib43c/libPreferences.a
Indexing .pio/build/release/lib43c/libPreferences.a
Compiling .pio/build/release/libdc4/BLE/BLEDevice.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEEddystoneTLM.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEEddystoneURL.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEExceptions.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEHIDDevice.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLERemoteCharacteristic.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLERemoteDescriptor.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLERemoteService.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEScan.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLESecurity.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEServer.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEService.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEServiceMap.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEUUID.cpp.o
/Users/odaki/.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLERemoteService.cpp: In member function 'void BLERemoteService::getCharacteristics(std::map<short unsigned int, BLERemoteCharacteristic*>*)':
/Users/odaki/.platformio/packages/framework-arduinoespressif32/libraries/BLE/src/BLERemoteService.cpp:246:89: warning: parameter 'pCharacteristicMap' set but not used [-Wunused-but-set-parameter]
 void BLERemoteService::getCharacteristics(std::map<uint16_t, BLERemoteCharacteristic*>* pCharacteristicMap) {
                                                                                         ^
Compiling .pio/build/release/libdc4/BLE/BLEUtils.cpp.o
Compiling .pio/build/release/libdc4/BLE/BLEValue.cpp.o
Compiling .pio/build/release/libdc4/BLE/FreeRTOS.cpp.o
Compiling .pio/build/release/libdc4/BLE/GeneralUtils.cpp.o
Compiling .pio/build/release/lib32c/FS/FS.cpp.o
Compiling .pio/build/release/lib32c/FS/vfs_api.cpp.o
Compiling .pio/build/release/lib5f2/SD/SD.cpp.o
Compiling .pio/build/release/lib5f2/SD/sd_diskio.cpp.o
Compiling .pio/build/release/lib5f2/SD/sd_diskio_crc.c.o
Compiling .pio/build/release/lib508/BluetoothSerial/BluetoothSerial.cpp.o
Compiling .pio/build/release/libd8f/WebServer/Parsing.cpp.o
Compiling .pio/build/release/libd8f/WebServer/WebServer.cpp.o
Compiling .pio/build/release/libd8f/WebServer/detail/mimetable.cpp.o
Compiling .pio/build/release/libc97/WiFiClientSecure/WiFiClientSecure.cpp.o
Archiving .pio/build/release/libdc4/libBLE.a
Archiving .pio/build/release/lib32c/libFS.a
Compiling .pio/build/release/libc97/WiFiClientSecure/ssl_client.cpp.o
Indexing .pio/build/release/lib32c/libFS.a
Indexing .pio/build/release/libdc4/libBLE.a
Compiling .pio/build/release/lib0b8/arduinoWebSockets/WebSockets.cpp.o
Archiving .pio/build/release/lib5f2/libSD.a
Indexing .pio/build/release/lib5f2/libSD.a
Archiving .pio/build/release/lib508/libBluetoothSerial.a
Indexing .pio/build/release/lib508/libBluetoothSerial.a
Compiling .pio/build/release/lib0b8/arduinoWebSockets/WebSocketsClient.cpp.o
Compiling .pio/build/release/lib0b8/arduinoWebSockets/WebSocketsServer.cpp.o
Compiling .pio/build/release/lib0b8/arduinoWebSockets/libb64/cdecode.c.o
Compiling .pio/build/release/lib0b8/arduinoWebSockets/libb64/cencode.c.o
Compiling .pio/build/release/lib0b8/arduinoWebSockets/libsha1/libsha1.c.o
Compiling .pio/build/release/libc86/DNSServer/DNSServer.cpp.o
Compiling .pio/build/release/libf36/ESP32SSDP/ESP32SSDP.cpp.o
Compiling .pio/build/release/lib460/ESPmDNS/ESPmDNS.cpp.o
Archiving .pio/build/release/libc97/libWiFiClientSecure.a
Indexing .pio/build/release/libc97/libWiFiClientSecure.a
Compiling .pio/build/release/lib311/SPIFFS/SPIFFS.cpp.o
Archiving .pio/build/release/libc86/libDNSServer.a
Indexing .pio/build/release/libc86/libDNSServer.a
Compiling .pio/build/release/lib43e/Update/Updater.cpp.o
Compiling .pio/build/release/lib2ac/ArduinoOTA/ArduinoOTA.cpp.o
Archiving .pio/build/release/libFrameworkArduinoVariant.a
Indexing .pio/build/release/libFrameworkArduinoVariant.a
Archiving .pio/build/release/lib0b8/libarduinoWebSockets.a
Archiving .pio/build/release/libd8f/libWebServer.a
Indexing .pio/build/release/lib0b8/libarduinoWebSockets.a
Indexing .pio/build/release/libd8f/libWebServer.a
Compiling .pio/build/release/FrameworkArduino/Esp.cpp.o
Compiling .pio/build/release/FrameworkArduino/FunctionalInterrupt.cpp.o
Compiling .pio/build/release/FrameworkArduino/HardwareSerial.cpp.o
Archiving .pio/build/release/libf36/libESP32SSDP.a
Indexing .pio/build/release/libf36/libESP32SSDP.a
Compiling .pio/build/release/FrameworkArduino/IPAddress.cpp.o
Archiving .pio/build/release/lib460/libESPmDNS.a
Indexing .pio/build/release/lib460/libESPmDNS.a
Compiling .pio/build/release/FrameworkArduino/IPv6Address.cpp.o
Archiving .pio/build/release/lib311/libSPIFFS.a
Indexing .pio/build/release/lib311/libSPIFFS.a
Compiling .pio/build/release/FrameworkArduino/MD5Builder.cpp.o
Compiling .pio/build/release/FrameworkArduino/Print.cpp.o
Archiving .pio/build/release/lib43e/libUpdate.a
Indexing .pio/build/release/lib43e/libUpdate.a
Compiling .pio/build/release/FrameworkArduino/Stream.cpp.o
Compiling .pio/build/release/FrameworkArduino/StreamString.cpp.o
Compiling .pio/build/release/FrameworkArduino/WMath.cpp.o
Archiving .pio/build/release/lib2ac/libArduinoOTA.a
Compiling .pio/build/release/FrameworkArduino/WString.cpp.o
Indexing .pio/build/release/lib2ac/libArduinoOTA.a
Compiling .pio/build/release/FrameworkArduino/base64.cpp.o
Compiling .pio/build/release/FrameworkArduino/cbuf.cpp.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-adc.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-bt.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-cpu.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-dac.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-gpio.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-i2c.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-ledc.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-matrix.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-misc.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-psram.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-rmt.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-sigmadelta.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-spi.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-time.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-timer.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-touch.c.o
Compiling .pio/build/release/FrameworkArduino/esp32-hal-uart.c.o
Compiling .pio/build/release/FrameworkArduino/libb64/cdecode.c.o
Compiling .pio/build/release/FrameworkArduino/libb64/cencode.c.o
Compiling .pio/build/release/FrameworkArduino/main.cpp.o
Compiling .pio/build/release/FrameworkArduino/stdlib_noniso.c.o
Compiling .pio/build/release/FrameworkArduino/wiring_pulse.c.o
Compiling .pio/build/release/FrameworkArduino/wiring_shift.c.o
Archiving .pio/build/release/libFrameworkArduino.a
Indexing .pio/build/release/libFrameworkArduino.a
Linking .pio/build/release/firmware.elf
Retrieving maximum program size .pio/build/release/firmware.elf
Checking size .pio/build/release/firmware.elf
Building .pio/build/release/firmware.bin
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [==        ]  22.0% (used 72108 bytes from 327680 bytes)
Flash: [========= ]  92.3% (used 1815346 bytes from 1966080 bytes)
esptool.py v2.6
=========================== [SUCCESS] Took 51.72 seconds ===========================

Environment    Status    Duration
-------------  --------  ------------
release        SUCCESS   00:00:51.719
============================ 1 succeeded in 00:00:51.719 ============================
```

Reference:
lib_deps
https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps
lib_dir
https://docs.platformio.org/en/latest/projectconf/section_platformio.html#projectconf-pio-lib-dir
