### PR TITLE
Suppress one-line case statements and fix atari custom

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AlignEscapedNewlines: Right
 AlignOperands: 'true'
 AlignTrailingComments: 'true'
 AllowShortBlocksOnASingleLine: 'true'
-AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortCaseLabelsOnASingleLine: 'false'
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: 'false'
 AllowShortLoopsOnASingleLine: 'false'

--- a/Grbl_Esp32/Custom/atari_1020.cpp
+++ b/Grbl_Esp32/Custom/atari_1020.cpp
@@ -121,7 +121,7 @@ void atari_home_task(void* pvParameters) {
         // this task will only last as long as it is homing
         if (atari_homing) {
             // must be in idle or alarm state
-            if (sys.state == STATE_IDLE) {
+            if (sys.state == State::Idle) {
                 switch (homing_phase) {
                     case HOMING_PHASE_FULL_APPROACH:           // a full width move to insure it hits left end
                         WebUI::inputBuffer.push("G90G0Z1\r");  // lift the pen
@@ -179,8 +179,8 @@ void atari_home_task(void* pvParameters) {
 void calc_solenoid(float penZ) {
     bool        isPenUp;
     static bool previousPenState = false;
-    uint32_t    solenoid_pen_pulse_len;                    // duty cycle of solenoid
-    isPenUp = ((penZ > 0) || (sys.state == STATE_ALARM));  // is pen above Z0 or is there an alarm
+    uint32_t    solenoid_pen_pulse_len;                     // duty cycle of solenoid
+    isPenUp = ((penZ > 0) || (sys.state == State::Alarm));  // is pen above Z0 or is there an alarm
     // if the state has not change, we only count down to the pull time
     if (previousPenState == isPenUp) {
         // if state is unchanged


### PR DESCRIPTION
`AllowShortCaseLabelsOnASingleLine: 'true'`
It works for simplifying break-only cases, but to me it feels like over-connecting lines.
This configuration runs the following format.
From:
```C++
        default:
            grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Unknown Switch %d", index);
            break;
```
To:
```C++
        default: grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Unknown Switch %d", index); break;
```

There seems to be a little bit of a change forgotten in the changes you put in to accommodate the enum class State.
We can keep as much of the original code as possible by adding this fix and then adding a small modification to Atari custom.