### PR TITLE
Fix i2s probing hung

### DIFF
--- a/Grbl_Esp32/src/GCode.cpp
+++ b/Grbl_Esp32/src/GCode.cpp
@@ -1507,9 +1507,6 @@ Error gc_execute_line(char* line, uint8_t client) {
     if (gc_state.modal.motion != Motion::None) {
         if (axis_command == AxisCommand::MotionMode) {
             GCUpdatePos gc_update_pos = GCUpdatePos::Target;
-#ifdef USE_I2S_STEPS
-            stepper_id_t save_stepper = current_stepper;
-#endif
             if (gc_state.modal.motion == Motion::Linear) {
                 //mc_line(gc_block.values.xyz, pl_data);
                 mc_line_kins(gc_block.values.xyz, pl_data, gc_state.position);
@@ -1533,12 +1530,6 @@ Error gc_execute_line(char* line, uint8_t client) {
 #ifndef ALLOW_FEED_OVERRIDE_DURING_PROBE_CYCLES
                 pl_data->motion.noFeedOverride = 1;
 #endif
-#ifdef USE_I2S_STEPS
-                save_stepper = current_stepper;  // remember the stepper
-                if (save_stepper == ST_I2S_STREAM) {
-                    stepper_switch(ST_I2S_STATIC);  // Change the stepper to reduce the delay for accurate probing.
-                }
-#endif
                 gc_update_pos = mc_probe_cycle(gc_block.values.xyz, pl_data, gc_parser_flags);
             }
             // As far as the parser is concerned, the position is now == target. In reality the
@@ -1549,11 +1540,6 @@ Error gc_execute_line(char* line, uint8_t client) {
             } else if (gc_update_pos == GCUpdatePos::System) {
                 gc_sync_position();  // gc_state.position[] = sys_position
             }                        // == GCUpdatePos::None
-#ifdef USE_I2S_STEPS
-            if (save_stepper == ST_I2S_STREAM && current_stepper != ST_I2S_STREAM) {
-                stepper_switch(ST_I2S_STREAM);  // Put the stepper back on.
-            }
-#endif
         }
     }
     // [21. Program flow ]:

--- a/Grbl_Esp32/src/I2SOut.cpp
+++ b/Grbl_Esp32/src/I2SOut.cpp
@@ -291,9 +291,27 @@ static int IRAM_ATTR i2s_out_start() {
 
     // Attach I2S to specified GPIO pin
     i2s_out_gpio_attach(i2s_out_ws_pin, i2s_out_bck_pin, i2s_out_data_pin);
-    //start DMA link
+
+    // reest TX/RX module
+    I2S0.conf.tx_reset = 1;
+    I2S0.conf.tx_reset = 0;
+    I2S0.conf.rx_reset = 1;
+    I2S0.conf.rx_reset = 0;
+
+#    ifdef USE_I2S_OUT_STREAM_IMPL
+    // reset DMA
+    I2S0.lc_conf.in_rst  = 1;
+    I2S0.lc_conf.in_rst  = 0;
+    I2S0.lc_conf.out_rst = 1;
+    I2S0.lc_conf.out_rst = 0;
+
+    I2S0.out_link.addr = (uint32_t)o_dma.desc[0];
+#    endif
+
+    // reset FIFO
     i2s_out_reset_fifo_without_lock();
 
+    // start DMA link
 #    ifdef USE_I2S_OUT_STREAM_IMPL
     if (i2s_out_pulser_status == PASSTHROUGH) {
         I2S0.conf_chan.tx_chan_mod = 3;  // 3:right+constant 4:left+constant (when tx_msb_right = 1)
@@ -303,21 +321,6 @@ static int IRAM_ATTR i2s_out_start() {
         I2S0.conf_single_data      = 0;
     }
 #    endif
-
-#    ifdef USE_I2S_OUT_STREAM_IMPL
-    //reset DMA
-    I2S0.lc_conf.in_rst  = 1;
-    I2S0.lc_conf.in_rst  = 0;
-    I2S0.lc_conf.out_rst = 1;
-    I2S0.lc_conf.out_rst = 0;
-
-    I2S0.out_link.addr = (uint32_t)o_dma.desc[0];
-#    endif
-
-    I2S0.conf.tx_reset = 1;
-    I2S0.conf.tx_reset = 0;
-    I2S0.conf.rx_reset = 1;
-    I2S0.conf.rx_reset = 0;
 
     I2S0.conf1.tx_stop_en = 1;  // BCK and WCK are suppressed while FIFO is empty
 
@@ -339,13 +342,14 @@ static int IRAM_ATTR i2s_out_start() {
 }
 
 #    ifdef USE_I2S_OUT_STREAM_IMPL
-
+// Fill out one DMA buffer
+// Call with the I2S_OUT_PULSER lock acquired.
+// Note that the lock is temporarily released while calling the callback function.
 static int IRAM_ATTR i2s_fillout_dma_buffer(lldesc_t* dma_desc) {
     uint32_t* buf = (uint32_t*)dma_desc->buf;
     o_dma.rw_pos  = 0;
     // It reuses the oldest (just transferred) buffer with the name "current"
     // and fills the buffer for later DMA.
-    I2S_OUT_PULSER_ENTER_CRITICAL();  // Lock pulser status
     if (i2s_out_pulser_status == STEPPING) {
         //
         // Fillout the buffer for pulse
@@ -408,7 +412,6 @@ static int IRAM_ATTR i2s_fillout_dma_buffer(lldesc_t* dma_desc) {
         o_dma.rw_pos                         = 0;  // If someone calls i2s_out_push_sample, make sure there is no buffer overflow
         i2s_out_remain_time_until_next_pulse = 0;
     }
-    I2S_OUT_PULSER_EXIT_CRITICAL();  // Unlock pulser status
 
     return 0;
 }
@@ -772,7 +775,6 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
     //
 
     // configure I2S data port interface.
-    i2s_out_reset_fifo();
 
     //reset i2s
     I2S0.conf.tx_reset = 1;
@@ -785,6 +787,8 @@ int IRAM_ATTR i2s_out_init(i2s_out_init_t& init_param) {
     I2S0.lc_conf.in_rst  = 0;
     I2S0.lc_conf.out_rst = 1;  // Set this bit to reset out DMA FSM. (R/W)
     I2S0.lc_conf.out_rst = 0;
+
+    i2s_out_reset_fifo_without_lock();
 
     //Enable and configure DMA
     I2S0.lc_conf.check_owner        = 0;

--- a/debug.ini
+++ b/debug.ini
@@ -6,14 +6,18 @@
 upload_port = COM3
 monitor_port = COM3
 ; macOS
-;upload_port = /dev/cu.usbserial-*
-;monitor_port = /dev/cu.usbserial-*
+;upload_port = /dev/cu.SLAB_USBtoUART
+;monitor_port = /dev/cu.SLAB_USBtoUART
+; macOS ESP-Prog
+;upload_port = /dev/cu.usbserial-14200
+;monitor_port = /dev/cu.usbserial-14201
+;upload_protocol = esp-prog
 ; Linux
 ;upload_port = /dev/ttyUSB*
 ;monitor_port = /dev/ttyUSB*
 build_flags =
     ${common.build_flags}
-	-DMACHINE_FILENAME=test_drive.h 
+	-DMACHINE_FILENAME=test_drive.h
 
 [env:debug]
 ; You can switch between debugging tools using debug_tool option

--- a/platformio.ini
+++ b/platformio.ini
@@ -49,7 +49,7 @@ board_build.flash_mode = qio
 build_flags = ${common.build_flags}
 src_filter =
     +<*.h> +<*.s> +<*.S> +<*.cpp> +<*.c> +<*.ino> +<src/>
-    -<.git/> -<data/> -<test/> -<tests/> -<Custom/>
+    -<.git/> -<data/> -<test/> -<tests/>
 
 [env:release]
 


### PR DESCRIPTION
Fix a hangup reported in the Slack channel of Grbl_ESP32.

It was too early to change the mode of I2S in Probing.
For example, this happens when probing immediately after the completion of a move, as shown below.
Outputs a message to change to pass-through mode and hung.
(Ignore the mixed output timing of 'ok'.)
```TEXT
G0 X1000 F100
G0 X0 F100
G38.2 X10 F50ok
ok
ok
ok
[MSG:Stop the I2S streaming and switch to the passthrough mode.]
```
It can probably also happen right after real time movement by JOGs. 

I will now fix the following.
- Check the system status
- Wait for the real time commands that are being executed to finish synchronizing.
- **Switch I2S mode.**

Homing doesn’t have the same phenomenon because it does the system status check first and then switches I2S.
If you try to homing while doing something, error 8 will return. 
(error 8 is STATUS_IDLE_ERROR: You have issued a command only allowed when the machine active state is Idle)