### PR TITLE
$sd/show and handle settings in SD files

### DIFF
--- a/Grbl_Esp32/src/ProcessSettings.cpp
+++ b/Grbl_Esp32/src/ProcessSettings.cpp
@@ -159,6 +159,16 @@ Error list_settings(const char* value, WebUI::AuthenticationLevel auth_level, We
     }
     return Error::Ok;
 }
+Error list_changed_settings(const char* value, WebUI::AuthenticationLevel auth_level, WebUI::ESPResponseStream* out) {
+    for (Setting* s = Setting::List; s; s = s->next()) {
+        const char* value = s->getStringValue();
+        if (!auth_failed(s, value, auth_level) && strcmp(value, s->getDefaultString())) {
+            show_setting(s->getName(), value, NULL, out);
+        }
+    }
+    grbl_sendf(out->client(), "(Passwords not shown)\r\n");
+    return Error::Ok;
+}
 Error list_commands(const char* value, WebUI::AuthenticationLevel auth_level, WebUI::ESPResponseStream* out) {
     for (Command* cp = Command::List; cp; cp = cp->next()) {
         const char* name    = cp->getName();
@@ -383,6 +393,7 @@ void make_grbl_commands() {
     new GrblCommand("+", "ExtendedSettings/List", report_extended_settings, notCycleOrHold);
     new GrblCommand("L", "GrblNames/List", list_grbl_names, notCycleOrHold);
     new GrblCommand("S", "Settings/List", list_settings, notCycleOrHold);
+    new GrblCommand("SC","Settings/ListChanged", list_changed_settings, notCycleOrHold);
     new GrblCommand("CMD", "Commands/List", list_commands, notCycleOrHold);
     new GrblCommand("E", "ErrorCodes/List", listErrorCodes, anyState);
     new GrblCommand("G", "GCode/Modes", report_gcode, anyState);

--- a/Grbl_Esp32/src/Protocol.cpp
+++ b/Grbl_Esp32/src/Protocol.cpp
@@ -142,7 +142,7 @@ void protocol_main_loop() {
             char fileLine[255];
             if (readFileLine(fileLine, 255)) {
                 SD_ready_next = false;
-                report_status_message(gc_execute_line(fileLine, SD_client), SD_client);
+                report_status_message(execute_line(fileLine, SD_client, SD_auth_level), SD_client);
             } else {
                 char temp[50];
                 sd_get_current_filename(temp);

--- a/Grbl_Esp32/src/SDCard.cpp
+++ b/Grbl_Esp32/src/SDCard.cpp
@@ -23,6 +23,7 @@
 File        myFile;
 bool        SD_ready_next = false;  // Grbl has processed a line and is waiting for another
 uint8_t     SD_client     = CLIENT_SERIAL;
+WebUI::AuthenticationLevel SD_auth_level = WebUI::AuthenticationLevel::LEVEL_GUEST;
 uint32_t    sd_current_line_number;     // stores the most recent line number read from the SD
 static char comment[LINE_BUFFER_SIZE];  // Line to be executed. Zero-terminated.
 

--- a/Grbl_Esp32/src/SDCard.h
+++ b/Grbl_Esp32/src/SDCard.h
@@ -31,6 +31,7 @@ const int SDCARD_BUSY_PARSING   = 8;
 
 extern bool    SD_ready_next;  // Grbl has processed a line and is waiting for another
 extern uint8_t SD_client;
+extern WebUI::AuthenticationLevel SD_auth_level;
 
 //bool sd_mount();
 uint8_t  get_sd_state(bool refresh);

--- a/Grbl_Esp32/src/Settings.h
+++ b/Grbl_Esp32/src/Settings.h
@@ -134,6 +134,7 @@ public:
     Error               setStringValue(String s) { return setStringValue(s.c_str()); }
     virtual const char* getStringValue() = 0;
     virtual const char* getCompatibleValue() { return getStringValue(); }
+    virtual const char* getDefaultString() = 0;
 };
 
 class IntSetting : public Setting {
@@ -173,6 +174,7 @@ public:
     void        addWebui(WebUI::JSONencoder*);
     Error       setStringValue(char* value);
     const char* getStringValue();
+    const char* getDefaultString();
 
     int32_t get() { return _currentValue; }
 };
@@ -202,6 +204,7 @@ public:
     Error       setStringValue(char* value);
     const char* getCompatibleValue();
     const char* getStringValue();
+    const char* getDefaultString();
 
     int32_t get() { return _currentValue; }
 };
@@ -263,6 +266,7 @@ public:
     void        addWebui(WebUI::JSONencoder*) {}
     Error       setStringValue(char* value);
     const char* getStringValue();
+    const char* getDefaultString();
 
     float get() { return _currentValue; }
 };
@@ -296,6 +300,7 @@ public:
     void        addWebui(WebUI::JSONencoder*);
     Error       setStringValue(char* value);
     const char* getStringValue();
+    const char* getDefaultString();
 
     const char* get() { return _currentValue.c_str(); }
 };
@@ -310,6 +315,7 @@ private:
     int8_t                                  _storedValue;
     int8_t                                  _currentValue;
     std::map<const char*, int8_t, cmp_str>* _options;
+    const char*                             enumToString(int8_t value);
 
 public:
     EnumSetting(const char*   description,
@@ -328,6 +334,7 @@ public:
     void        addWebui(WebUI::JSONencoder*);
     Error       setStringValue(char* value);
     const char* getStringValue();
+    const char* getDefaultString();
 
     int8_t get() { return _currentValue; }
 };
@@ -357,6 +364,7 @@ public:
     Error       setStringValue(char* value);
     const char* getCompatibleValue();
     const char* getStringValue();
+    const char* getDefaultString();
 
     bool get() { return _currentValue; }
 };
@@ -388,6 +396,7 @@ public:
     void        addWebui(WebUI::JSONencoder*);
     Error       setStringValue(char* value);
     const char* getStringValue();
+    const char* getDefaultString();
 
     uint32_t get() { return _currentValue; }
 };

--- a/Grbl_Esp32/src/WebUI/ESPResponse.cpp
+++ b/Grbl_Esp32/src/WebUI/ESPResponse.cpp
@@ -96,9 +96,6 @@ namespace WebUI {
             return;
         }
 #endif
-        if (_client == CLIENT_WEBUI) {
-            return;  //this is sanity check
-        }
         grbl_send(_client, data);
     }
 

--- a/Grbl_Esp32/src/WebUI/WebSettings.cpp
+++ b/Grbl_Esp32/src/WebUI/WebSettings.cpp
@@ -684,10 +684,6 @@ namespace WebUI {
                 return Error::SdFailedBusy;
             }
         }
-        if (sys.state != State::Idle) {
-            webPrintln("Busy");
-            return Error::IdleError;
-        }
         if (!openFile(SD, path.c_str())) {
             report_status_message(Error::SdFailedRead, (espresponse) ? espresponse->client() : CLIENT_ALL);
             webPrintln("");
@@ -696,6 +692,9 @@ namespace WebUI {
         return Error::Ok;
     }
     static Error showSDFile(char* parameter, AuthenticationLevel auth_level) {  // ESP221
+        if (sys.state != State::Idle && sys.state != State::Alarm) {
+            return Error::IdleError;
+        }
         Error err;
         if ((err = openSDFile(parameter)) != Error::Ok) {
             return err;
@@ -712,6 +711,10 @@ namespace WebUI {
 
     static Error runSDFile(char* parameter, AuthenticationLevel auth_level) {  // ESP220
         Error err;
+        if (sys.state != State::Idle) {
+            webPrintln("Busy");
+            return Error::IdleError;
+        }
         if ((err = openSDFile(parameter)) != Error::Ok) {
             return err;
         }

--- a/Grbl_Esp32/src/WebUI/WebSettings.cpp
+++ b/Grbl_Esp32/src/WebUI/WebSettings.cpp
@@ -289,6 +289,10 @@ namespace WebUI {
     }
 
     static Error runLocalFile(char* parameter, AuthenticationLevel auth_level) {  // ESP700
+        if (sys.state != State::Idle) {
+            webPrintln("Busy");
+            return Error::IdleError;
+        }
         String path = trim(parameter);
         if ((path.length() > 0) && (path[0] != '/')) {
             path = "/" + path;
@@ -322,6 +326,9 @@ namespace WebUI {
     }
 
     static Error showLocalFile(char* parameter, AuthenticationLevel auth_level) {  // ESP701
+        if (sys.state != State::Idle && sys.state != State::Alarm) {
+            return Error::IdleError;
+        }
         String path = trim(parameter);
         if ((path.length() > 0) && (path[0] != '/')) {
             path = "/" + path;

--- a/Grbl_Esp32/src/WebUI/WebSettings.cpp
+++ b/Grbl_Esp32/src/WebUI/WebSettings.cpp
@@ -666,10 +666,13 @@ namespace WebUI {
 
 #ifdef ENABLE_SD_CARD
     static Error openSDFile(char* parameter) {
-        parameter = trim(parameter);
         if (*parameter == '\0') {
             webPrintln("Missing file name!");
             return Error::InvalidValue;
+        }
+        String path = trim(parameter);
+        if (path[0] != '/') {
+            path = "/" + path;
         }
         int8_t state = get_sd_state(true);
         if (state != SDCARD_IDLE) {
@@ -685,7 +688,7 @@ namespace WebUI {
             webPrintln("Busy");
             return Error::IdleError;
         }
-        if (!openFile(SD, parameter)) {
+        if (!openFile(SD, path.c_str())) {
             report_status_message(Error::SdFailedRead, (espresponse) ? espresponse->client() : CLIENT_ALL);
             webPrintln("");
             return Error::SdFailedOpenFile;


### PR DESCRIPTION
The main purpose is to handle settings in SD files, so you can have a SD file that establishes a list of setting values.

As a related helpful tool, there is a new command  $Sd/Show=<path>, which displays the contents of <path> on the serial port .  Ideally it would display in the WebUI console window too but I haven't figured that out yet.

One issue with $Sd/Show is that it displays the entire file.  That is okay for short files, e.g. ones containing settings or simple gcode test files, but displaying enormous files can be tedious.  There should be some option for limiting the number of lines shown.