### PR TITLE
Fixed WebUI crash

### DIFF
--- a/Grbl_Esp32/src/WebUI/WebServer.cpp
+++ b/Grbl_Esp32/src/WebUI/WebServer.cpp
@@ -430,8 +430,6 @@ namespace WebUI {
     }
 #    endif
 
-    bool Web_Server::is_realtime_cmd(char c) { return is_realtime_cmd(c); }
-
     void Web_Server::_handle_web_command(bool silent) {
         //to save time if already disconnected
         //if (_webserver->hasArg ("PAGEID") ) {
@@ -501,7 +499,7 @@ namespace WebUI {
                 }
                 if (scmd.length() > 1) {
                     scmd += "\n";
-                } else if (!is_realtime_cmd(scmd[0])) {
+                } else if (!is_realtime_command(scmd[0])) {
                     scmd += "\n";
                 }
                 if (!Serial2Socket.push(scmd.c_str())) {

--- a/Grbl_Esp32/src/WebUI/WebServer.h
+++ b/Grbl_Esp32/src/WebUI/WebServer.h
@@ -87,7 +87,6 @@ namespace WebUI {
         static void handleFileList();
         static void handleUpdate();
         static void WebUpdateUpload();
-        static bool is_realtime_cmd(char c);
         static void pushError(int code, const char* st, bool web_error = 500, uint16_t timeout = 1000);
         static void cancelUpload();
 #ifdef ENABLE_SD_CARD


### PR DESCRIPTION
While eliminating a redundant definition of is_realtime_command(),
I inadvertently introduced a recursion due to the similarity of
the names "is_realtime_command()" and "is_realtime_cmd()".  The
solution is to eliminate the latter entirely.