### PR TITLE
Fixed incremental compilation by emitting a pio_machine.h file instea…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ __vm/
 *.vcxproj.filters
 *.suo
 Grbl_Esp32.ino.cpp
+pio_machine.h
+packages/

--- a/builder.py
+++ b/builder.py
@@ -14,7 +14,10 @@ def buildMachine(baseName, verbose=True, extraArgs=None):
     if extraArgs:
         cmd.append(extraArgs)
     displayName = baseName
-    flags = '-DMACHINE_FILENAME=' + baseName
+    f = open("Grbl_Esp32/src/Machines/pio_machine.h", "w")
+    f.write("#include \"" + baseName + "\"")
+    f.close()
+    flags = '-DMACHINE_FILENAME=pio_machine.h'    
     print('Building machine ' + displayName)
     env['PLATFORMIO_BUILD_FLAGS'] = flags
     if verbose:


### PR DESCRIPTION
Fixed incremental compilation by emitting a pio_machine.h file instead of using the -D preprocessor option that breaks it.
The pio_machine.h file will be emitted in the machine folder. Because of that, I added it to the .gitignore.

NOTE: ONLY THE PYTHON SCRIPTS HAVE CHANGED! SH/PS1 is still the same for now.

Test results of build-all show that the first build is slow, and subsequent builds are much faster:

C:\devt\Grbl_Esp32>python build-all.py
Building machine 3axis_rs485.h
========================= [SUCCESS] Took 55.99 seconds =========================

Building machine 3axis_v3.h
========================= [SUCCESS] Took 23.42 seconds =========================

Building machine 3axis_v4.h
========================= [SUCCESS] Took 23.37 seconds =========================

Building machine 3axis_xyx.h
========================= [SUCCESS] Took 23.27 seconds =========================

Building machine 4axis_external_driver.h
========================= [SUCCESS] Took 22.98 seconds =========================

Building machine 6_pack_Lowrider_stepstick_v1.h
========================= [SUCCESS] Took 23.19 seconds =========================

Building machine 6_pack_MPCNC_stepstick_v1.h
========================= [SUCCESS] Took 23.71 seconds =========================

Building machine 6_pack_stepstick_v1.h
========================= [SUCCESS] Took 22.92 seconds =========================

Building machine 6_pack_stepstick_XYZ_v1.h
========================= [SUCCESS] Took 23.05 seconds =========================

Building machine 6_pack_trinamic_stallguard.h
========================= [SUCCESS] Took 23.40 seconds =========================

Building machine atari_1020.h
========================= [SUCCESS] Took 23.24 seconds =========================

Building machine espduino.h
========================= [SUCCESS] Took 22.78 seconds =========================

Building machine i2s_out_xxyyzz.h
========================= [SUCCESS] Took 22.52 seconds =========================

Building machine i2s_out_xyzabc.h
========================= [SUCCESS] Took 23.15 seconds =========================

Building machine i2s_out_xyzabc_trinamic.h
========================= [SUCCESS] Took 23.67 seconds =========================

Building machine lowrider_v1p2.h
========================= [SUCCESS] Took 23.71 seconds =========================

Building machine midtbot.h
========================= [SUCCESS] Took 23.13 seconds =========================

Building machine mpcnc_laser_module_v1p2.h
========================= [SUCCESS] Took 23.20 seconds =========================

Building machine mpcnc_v1p1.h
========================= [SUCCESS] Took 23.36 seconds =========================

Building machine mpcnc_v1p2.h
========================= [SUCCESS] Took 23.54 seconds =========================

Building machine pen_laser.h
========================= [SUCCESS] Took 23.80 seconds =========================

Building machine polar_coaster.h
========================= [SUCCESS] Took 23.54 seconds =========================

Building machine spi_daisy_4axis_xyyz.h
========================= [SUCCESS] Took 23.25 seconds =========================

Building machine spi_daisy_4axis_xyz.h
========================= [SUCCESS] Took 23.10 seconds =========================

Building machine spi_daisy_4axis_xyza.h
========================= [SUCCESS] Took 23.23 seconds =========================

Building machine tapster3.h
========================= [SUCCESS] Took 23.05 seconds =========================

Building machine template.h
========================= [SUCCESS] Took 23.01 seconds =========================

Building machine test_drive.h
========================= [SUCCESS] Took 22.95 seconds =========================

Building machine tmc2130_pen.h
========================= [SUCCESS] Took 22.88 seconds =========================
