### PR TITLE
Swag at YAML config files - for discussion only

### DIFF
--- a/Grbl_Esp32/src/MachineYAML/3axis_rs485.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_rs485.yaml
@@ -1,0 +1,35 @@
+---
+name: 3axis-rs485
+x:
+        limit: gpio.33:low
+        stepstick:
+                step: gpio.4
+                direction: gpio.16
+y:
+        limit: gpio.32:low
+        stepstick:
+                step: gpio.18
+                direction: gpio.18
+y2:
+        stepstick:
+                step: gpio.19
+                direction: gpio.21
+z:
+        limit: gpio.34:low
+        stepstick:
+                step: gpio.22
+                direction: gpio.23
+spindle:
+        VFD-RS485:
+                TxD: gpio.13
+                RTS: gpio.15
+                RxD: gpio.2
+                debug: on
+homing:
+        cycle0: x
+        cycle1: xy
+probe: gpio.14
+reset: gpio.27:low
+feed-hold: gpio.26:low
+cycle-start: gpio.25:low
+

--- a/Grbl_Esp32/src/MachineYAML/3axis_rs485.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_rs485.yaml
@@ -30,7 +30,8 @@ homing:
     - x
     - xy
 probe: gpio.14
-reset: gpio.27:low
-feed-hold: gpio.26:low
-cycle-start: gpio.25:low
+control:
+  reset: gpio.27:low
+  feed-hold: gpio.26:low
+  cycle-start: gpio.25:low
 

--- a/Grbl_Esp32/src/MachineYAML/3axis_rs485.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_rs485.yaml
@@ -1,33 +1,34 @@
 ---
 name: 3axis-rs485
 x:
-        limit: gpio.33:low
-        stepstick:
-                step: gpio.4
-                direction: gpio.16
+  limit: gpio.33:low
+  stepstick:
+    step: gpio.4
+    direction: gpio.16
 y:
-        limit: gpio.32:low
-        stepstick:
-                step: gpio.18
-                direction: gpio.18
+  limit: gpio.32:low
+  stepstick:
+    step: gpio.18
+    direction: gpio.18
 y2:
-        stepstick:
-                step: gpio.19
-                direction: gpio.21
+  stepstick:
+    step: gpio.19
+    direction: gpio.21
 z:
-        limit: gpio.34:low
-        stepstick:
-                step: gpio.22
-                direction: gpio.23
+  limit: gpio.34:low
+  stepstick:
+    step: gpio.22
+    direction: gpio.23
 spindle:
-        VFD-RS485:
-                TxD: gpio.13
-                RTS: gpio.15
-                RxD: gpio.2
-                debug: on
+  VFD-RS485:
+    TxD: gpio.13
+    RTS: gpio.15
+    RxD: gpio.2
+    debug: on
 homing:
-        cycle0: x
-        cycle1: xy
+  cycles:
+    - x
+    - xy
 probe: gpio.14
 reset: gpio.27:low
 feed-hold: gpio.26:low

--- a/Grbl_Esp32/src/MachineYAML/3axis_v3.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_v3.yaml
@@ -1,27 +1,28 @@
 ---
 name: esp32_v3.5
-
+board: bdring-3axis-v3
+defaults:
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.2:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
+  limit: gpio.2:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
 z:
-        limit: gpio.15:low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-steppers:
-        disable: gpio.13
+  limit: gpio.15:low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
 spindle:
-        pwm:
-                output: gpio.17
-                enable: gpio.22
+  pwm:
+    output: gpio.17
+    enable: gpio.22
 mist: gpio.21
 flood: gpio.16
 probe: gpio.32

--- a/Grbl_Esp32/src/MachineYAML/3axis_v3.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_v3.yaml
@@ -23,10 +23,12 @@ spindle:
   pwm:
     output: gpio.17
     enable: gpio.22
-mist: gpio.21
-flood: gpio.16
+coolant:
+  mist: gpio.21
+  flood: gpio.16
 probe: gpio.32
-door: gpio.35:low
-reset: gpio.34:low
-feed-hold: gpio.36:low
-cycle-start: gpio.39:low
+control:
+  door: gpio.35:low
+  reset: gpio.34:low
+  feed-hold: gpio.36:low
+  cycle-start: gpio.39:low

--- a/Grbl_Esp32/src/MachineYAML/3axis_v3.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_v3.yaml
@@ -1,0 +1,31 @@
+---
+name: esp32_v3.5
+
+x:
+        limit: gpio.2:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+z:
+        limit: gpio.15:low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+steppers:
+        disable: gpio.13
+spindle:
+        pwm:
+                output: gpio.17
+                enable: gpio.22
+mist: gpio.21
+flood: gpio.16
+probe: gpio.32
+door: gpio.35:low
+reset: gpio.34:low
+feed-hold: gpio.36:low
+cycle-start: gpio.39:low

--- a/Grbl_Esp32/src/MachineYAML/3axis_v4.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_v4.yaml
@@ -1,6 +1,6 @@
 ---
 name: esp32_v4
-board:bdring-3axis-v4
+board: bdring-3axis-v4
 defaults:
   steppers:
     disable: gpio.13
@@ -23,6 +23,7 @@ spindle:
   pwm:
     output: gpio.2
     enable: gpio.22
-mist: gpio.21
-flood: gpio.25
+coolant:
+  mist: gpio.21
+  flood: gpio.25
 probe: gpio.32

--- a/Grbl_Esp32/src/MachineYAML/3axis_v4.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_v4.yaml
@@ -1,0 +1,26 @@
+---
+name: esp32_v4
+x:
+        limit: gpio.17:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.14
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.26
+                direction: gpio.15
+z:
+        limit: gpio.16:low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+steppers:
+        disable: gpio.13
+spindle:
+        pwm:
+                output: gpio.2
+                enable: gpio.22
+mist: gpio.21
+flood: gpio.25
+probe: gpio.32

--- a/Grbl_Esp32/src/MachineYAML/3axis_v4.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_v4.yaml
@@ -1,26 +1,28 @@
 ---
 name: esp32_v4
+board:bdring-3axis-v4
+defaults:
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.17:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.14
+  limit: gpio.17:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.14
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.26
-                direction: gpio.15
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.26
+    direction: gpio.15
 z:
-        limit: gpio.16:low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-steppers:
-        disable: gpio.13
+  limit: gpio.16:low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
 spindle:
-        pwm:
-                output: gpio.2
-                enable: gpio.22
+  pwm:
+    output: gpio.2
+    enable: gpio.22
 mist: gpio.21
 flood: gpio.25
 probe: gpio.32

--- a/Grbl_Esp32/src/MachineYAML/3axis_xyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_xyz.yaml
@@ -1,27 +1,27 @@
 ---
 name: esp32_v4_xyz
-
+board:bdring-3axis-v4
+defaults:
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.17:low
-        stepstick:
-                step: gpio.26
-                direction: gpio.15
+  limit: gpio.17:low
+  stepstick:
+    step: gpio.26
+    direction: gpio.15
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.14
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.14
 z:
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-steppers:
-        disable: gpio.13
-
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
 spindle:
-        pwm:
-                output: gpio.2
-                enable: gpio.22
+  pwm:
+    output: gpio.2
+    enable: gpio.22
 mist: gpio.21
 flood: gpio.25
 probe: gpio.32

--- a/Grbl_Esp32/src/MachineYAML/3axis_xyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_xyz.yaml
@@ -1,0 +1,31 @@
+---
+name: esp32_v4_xyz
+
+x:
+        limit: gpio.17:low
+        stepstick:
+                step: gpio.26
+                direction: gpio.15
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.14
+z:
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+steppers:
+        disable: gpio.13
+
+spindle:
+        pwm:
+                output: gpio.2
+                enable: gpio.22
+mist: gpio.21
+flood: gpio.25
+probe: gpio.32
+door: gpio.35:low
+reset: gpio.34:low
+feed-hold: gpio.36:low
+cycle-start: gpio.39:low

--- a/Grbl_Esp32/src/MachineYAML/3axis_xyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/3axis_xyz.yaml
@@ -22,10 +22,12 @@ spindle:
   pwm:
     output: gpio.2
     enable: gpio.22
-mist: gpio.21
-flood: gpio.25
+coolant:
+  mist: gpio.21
+  flood: gpio.25
 probe: gpio.32
-door: gpio.35:low
-reset: gpio.34:low
-feed-hold: gpio.36:low
-cycle-start: gpio.39:low
+control:
+  door: gpio.35:low
+  reset: gpio.34:low
+  feed-hold: gpio.36:low
+  cycle-start: gpio.39:low

--- a/Grbl_Esp32/src/MachineYAML/4axis_external_driver.yaml
+++ b/Grbl_Esp32/src/MachineYAML/4axis_external_driver.yaml
@@ -1,0 +1,33 @@
+---
+name: External 4 Axis Driver Board V2
+x:
+        limit: gpio.34:low
+        external-stepper:
+                step: gpio.0
+                direction: gpio.2
+y:
+        limit: gpio.35:low
+        external-stepper:
+                step: gpio.26
+                direction: gpio.15
+z:
+        limit: gpio.36:low
+        external-stepper:
+                step: gpio.27
+                direction: gpio.33
+a:
+	limit: gpio.39:low
+        external-stepper:
+                step: gpio.12
+                direction: gpio.14
+steppers:
+        disable: gpio.13
+spindle:
+        huanyang:
+                TxD: gpio.17
+                RxD: gpio.4
+                RTS: gpio.16
+                debug: on
+
+probe: gpio.32
+mist: gpio.21

--- a/Grbl_Esp32/src/MachineYAML/4axis_external_driver.yaml
+++ b/Grbl_Esp32/src/MachineYAML/4axis_external_driver.yaml
@@ -1,33 +1,34 @@
 ---
 name: External 4 Axis Driver Board V2
+defaults:
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.34:low
-        external-stepper:
-                step: gpio.0
-                direction: gpio.2
+  limit: gpio.34:low
+  external-stepper:
+    step: gpio.0
+    direction: gpio.2
 y:
-        limit: gpio.35:low
-        external-stepper:
-                step: gpio.26
-                direction: gpio.15
+  limit: gpio.35:low
+  external-stepper:
+    step: gpio.26
+    direction: gpio.15
 z:
-        limit: gpio.36:low
-        external-stepper:
-                step: gpio.27
-                direction: gpio.33
+  limit: gpio.36:low
+  external-stepper:
+    step: gpio.27
+    direction: gpio.33
 a:
-	limit: gpio.39:low
-        external-stepper:
-                step: gpio.12
-                direction: gpio.14
-steppers:
-        disable: gpio.13
+  limit: gpio.39:low
+  external-stepper:
+    step: gpio.12
+    direction: gpio.14
 spindle:
-        huanyang:
-                TxD: gpio.17
-                RxD: gpio.4
-                RTS: gpio.16
-                debug: on
+  huanyang:
+    TxD: gpio.17
+    RxD: gpio.4
+    RTS: gpio.16
+    debug: on
 
 probe: gpio.32
 mist: gpio.21

--- a/Grbl_Esp32/src/MachineYAML/6_pack_Lowrider_stepstick_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_Lowrider_stepstick_v1.yaml
@@ -1,0 +1,44 @@
+---
+name: 6 Pack Lowrider XYYZZ V1 (StepStick)
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+x:
+        limit: gpio.33:low
+        stepstick:
+                disable: i2so.0
+                direction: i2so.1
+                step: i2so.2
+                ms3: i2so.3
+y:
+        limit: gpio.32:low
+        stepstick:
+                direction: i2so.4
+                step: i2so.5
+                ms3: i2so.6
+                disable: i2so.7
+y2:
+        limit: gpio.35:low
+        stepstick:
+                disable: i2so.8
+                direction: i2so.9
+                step: i2so.10
+                ms3: i2so.11
+z:
+        limit: gpio.34:low
+        stepstick:
+                direction: i2so.12
+                step: i2so.13
+                ms3: i2so.14
+                disable: i2so.15
+z2:
+        limit: gpio.2:low
+        stepstick:
+                disable: i2so.16
+                direction: i2so.17
+                step: i2so.18
+                ms3: i2so.19
+steppers:
+        reset: gpio.19
+        pulse: 4

--- a/Grbl_Esp32/src/MachineYAML/6_pack_Lowrider_stepstick_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_Lowrider_stepstick_v1.yaml
@@ -1,44 +1,46 @@
 ---
 name: 6 Pack Lowrider XYYZZ V1 (StepStick)
+board: bdring-6pack
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 4
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.33:low
-        stepstick:
-                disable: i2so.0
-                direction: i2so.1
-                step: i2so.2
-                ms3: i2so.3
+  limit: gpio.33:low
+  stepstick:
+    disable: i2so.0
+    direction: i2so.1
+    step: i2so.2
+    ms3: i2so.3
 y:
-        limit: gpio.32:low
-        stepstick:
-                direction: i2so.4
-                step: i2so.5
-                ms3: i2so.6
-                disable: i2so.7
+  limit: gpio.32:low
+  stepstick:
+    direction: i2so.4
+    step: i2so.5
+    ms3: i2so.6
+    disable: i2so.7
 y2:
-        limit: gpio.35:low
-        stepstick:
-                disable: i2so.8
-                direction: i2so.9
-                step: i2so.10
-                ms3: i2so.11
+  limit: gpio.35:low
+  stepstick:
+    disable: i2so.8
+    direction: i2so.9
+    step: i2so.10
+    ms3: i2so.11
 z:
-        limit: gpio.34:low
-        stepstick:
-                direction: i2so.12
-                step: i2so.13
-                ms3: i2so.14
-                disable: i2so.15
+  limit: gpio.34:low
+  stepstick:
+    direction: i2so.12
+    step: i2so.13
+    ms3: i2so.14
+    disable: i2so.15
 z2:
-        limit: gpio.2:low
-        stepstick:
-                disable: i2so.16
-                direction: i2so.17
-                step: i2so.18
-                ms3: i2so.19
-steppers:
-        reset: gpio.19
-        pulse: 4
+  limit: gpio.2:low
+  stepstick:
+    disable: i2so.16
+    direction: i2so.17
+    step: i2so.18
+    ms3: i2so.19

--- a/Grbl_Esp32/src/MachineYAML/6_pack_MPCNC_stepstick_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_MPCNC_stepstick_v1.yaml
@@ -1,44 +1,46 @@
 ---
 name: 6 Pack MPCNC XYZXY V1 (StepStick)
+board: bdring-6pack
+defaults:
+  steppers:
+    reset: gpio.19
+    pulse: 4
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.33:low
-        stepstick:
-                disable: i2so.0
-                direction: i2so.1
-                step: i2so.2
-                ms3: i2so.3
+  limit: gpio.33:low
+  stepstick:
+    disable: i2so.0
+    direction: i2so.1
+    step: i2so.2
+    ms3: i2so.3
 x2:
-        limit: gpio.34:low
-        stepstick:
-                direction: i2so.12
-                step: i2so.13
-                ms3: i2so.14
-                disable: i2so.15
+  limit: gpio.34:low
+  stepstick:
+    direction: i2so.12
+    step: i2so.13
+    ms3: i2so.14
+    disable: i2so.15
 y:
-        limit: gpio.32:low
-        stepstick:
-                direction: i2so.4
-                step: i2so.5
-                ms3: i2so.6
-                disable: i2so.7
+  limit: gpio.32:low
+  stepstick:
+    direction: i2so.4
+    step: i2so.5
+    ms3: i2so.6
+    disable: i2so.7
 y2:
-        limit: gpio.2:low
-        stepstick:
-                disable: i2so.16
-                direction: i2so.17
-                step: i2so.18
-                ms3: i2so.19
+  limit: gpio.2:low
+  stepstick:
+    disable: i2so.16
+    direction: i2so.17
+    step: i2so.18
+    ms3: i2so.19
 z:
-        limit: gpio.35:low
-        stepstick:
-                disable: i2so.8
-                direction: i2so.9
-                step: i2so.10
-                ms3: i2so.11
-steppers:
-        reset: gpio.19
-        pulse: 4
+  limit: gpio.35:low
+  stepstick:
+    disable: i2so.8
+    direction: i2so.9
+    step: i2so.10
+    ms3: i2so.11

--- a/Grbl_Esp32/src/MachineYAML/6_pack_MPCNC_stepstick_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_MPCNC_stepstick_v1.yaml
@@ -1,0 +1,44 @@
+---
+name: 6 Pack MPCNC XYZXY V1 (StepStick)
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+x:
+        limit: gpio.33:low
+        stepstick:
+                disable: i2so.0
+                direction: i2so.1
+                step: i2so.2
+                ms3: i2so.3
+x2:
+        limit: gpio.34:low
+        stepstick:
+                direction: i2so.12
+                step: i2so.13
+                ms3: i2so.14
+                disable: i2so.15
+y:
+        limit: gpio.32:low
+        stepstick:
+                direction: i2so.4
+                step: i2so.5
+                ms3: i2so.6
+                disable: i2so.7
+y2:
+        limit: gpio.2:low
+        stepstick:
+                disable: i2so.16
+                direction: i2so.17
+                step: i2so.18
+                ms3: i2so.19
+z:
+        limit: gpio.35:low
+        stepstick:
+                disable: i2so.8
+                direction: i2so.9
+                step: i2so.10
+                ms3: i2so.11
+steppers:
+        reset: gpio.19
+        pulse: 4

--- a/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_XYZ_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_XYZ_v1.yaml
@@ -1,24 +1,26 @@
 ---
 name: 6 Pack Controller StepStick XYZ
+board: bdring-6pack
+defaults:
+  steppers:
+    reset: gpio.19
+    pulse: 4
 i2so:
-	bck: gpio.22
-	ws: gpio.17
-	data: gpio.21
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-	limit: gpio.33:low
-	stepstick:
-		6pack-socket1
-	spmm: 800
+  limit: gpio.33:low
+  stepstick:
+    6pack-socket1
+  spmm: 800
 y:
-	limit: gpio.32:low
-	stepstick:
-		6pack-socket2
-	spmm: 800
+  limit: gpio.32:low
+  stepstick:
+    6pack-socket2
+  spmm: 800
 z:
-	limit: gpio.35:low
-	stepstick:
-		6pack-socket3
-	spmm: 800
-steppers:
-        reset: gpio.19
-        pulse: 4
+  limit: gpio.35:low
+  stepstick:
+    6pack-socket3
+  spmm: 800

--- a/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_XYZ_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_XYZ_v1.yaml
@@ -1,0 +1,24 @@
+---
+name: 6 Pack Controller StepStick XYZ
+i2so:
+	bck: gpio.22
+	ws: gpio.17
+	data: gpio.21
+x:
+	limit: gpio.33:low
+	stepstick:
+		6pack-socket1
+	spmm: 800
+y:
+	limit: gpio.32:low
+	stepstick:
+		6pack-socket2
+	spmm: 800
+z:
+	limit: gpio.35:low
+	stepstick:
+		6pack-socket3
+	spmm: 800
+steppers:
+        reset: gpio.19
+        pulse: 4

--- a/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_v1.yaml
@@ -1,44 +1,46 @@
 ---
 name: 6 Pack Controller V1 (StepStick)
+board: bdring-6pack
+defaults:
+  steppers:
+    reset: gpio.19
+    pulse: 4
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.33:low
-        stepstick:
-                disable: i2so.0
-                direction: i2so.1
-                step: i2so.2
-                ms3: i2so.3
+  limit: gpio.33:low
+  stepstick:
+    disable: i2so.0
+    direction: i2so.1
+    step: i2so.2
+    ms3: i2so.3
 x2:
-        limit: gpio.34:low
-        stepstick:
-                direction: i2so.12
-                step: i2so.13
-                ms3: i2so.14
-                disable: i2so.15
+  limit: gpio.34:low
+  stepstick:
+    direction: i2so.12
+    step: i2so.13
+    ms3: i2so.14
+    disable: i2so.15
 y:
-        limit: gpio.32:low
-        stepstick:
-                direction: i2so.4
-                step: i2so.5
-                ms3: i2so.6
-                disable: i2so.7
+  limit: gpio.32:low
+  stepstick:
+    direction: i2so.4
+    step: i2so.5
+    ms3: i2so.6
+    disable: i2so.7
 y2:
-        limit: gpio.2:low
-        stepstick:
-                disable: i2so.16
-                direction: i2so.17
-                step: i2so.18
-                ms3: i2so.19
+  limit: gpio.2:low
+  stepstick:
+    disable: i2so.16
+    direction: i2so.17
+    step: i2so.18
+    ms3: i2so.19
 z:
-        limit: gpio.35:low
-        stepstick:
-                disable: i2so.8
-                direction: i2so.9
-                step: i2so.10
-                ms3: i2so.11
-steppers:
-        reset: gpio.19
-        pulse: 4
+  limit: gpio.35:low
+  stepstick:
+    disable: i2so.8
+    direction: i2so.9
+    step: i2so.10
+    ms3: i2so.11

--- a/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_stepstick_v1.yaml
@@ -1,0 +1,44 @@
+---
+name: 6 Pack Controller V1 (StepStick)
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+x:
+        limit: gpio.33:low
+        stepstick:
+                disable: i2so.0
+                direction: i2so.1
+                step: i2so.2
+                ms3: i2so.3
+x2:
+        limit: gpio.34:low
+        stepstick:
+                direction: i2so.12
+                step: i2so.13
+                ms3: i2so.14
+                disable: i2so.15
+y:
+        limit: gpio.32:low
+        stepstick:
+                direction: i2so.4
+                step: i2so.5
+                ms3: i2so.6
+                disable: i2so.7
+y2:
+        limit: gpio.2:low
+        stepstick:
+                disable: i2so.16
+                direction: i2so.17
+                step: i2so.18
+                ms3: i2so.19
+z:
+        limit: gpio.35:low
+        stepstick:
+                disable: i2so.8
+                direction: i2so.9
+                step: i2so.10
+                ms3: i2so.11
+steppers:
+        reset: gpio.19
+        pulse: 4

--- a/Grbl_Esp32/src/MachineYAML/6_pack_trinamic_stallguard.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_trinamic_stallguard.yaml
@@ -1,0 +1,58 @@
+---
+name: 6 Pack Controller StepStick XYZ
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+x:
+        limit: gpio.33:low
+        tmc2130:
+		6pack-socket1
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+y:
+	limit: gpio.32:low
+	tmc2130:
+		6pack-socket2
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+z:
+	limit: gpio.35:low
+	tmc2130:
+		6pack-socket3
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+a:
+	limit: gpio.34:low
+	tmc2130:
+		6pack-socket4
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+b:
+	limit: gpio.39:low
+	tmc2130:
+		6pack-socket5
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+c:
+	limit: gpio.36:low
+	tmc2130:
+		6pack-socket6
+                rsense: 0.11
+                run: coolstep
+                homing: stallguard
+
+steppers:
+        reset: gpio.19
+        pulse: 4
+
+spindle:
+        pwm:
+                output: gpio.26
+                enable: gpio.4
+                direction: gpio.16

--- a/Grbl_Esp32/src/MachineYAML/6_pack_trinamic_stallguard.yaml
+++ b/Grbl_Esp32/src/MachineYAML/6_pack_trinamic_stallguard.yaml
@@ -1,58 +1,44 @@
 ---
 name: 6 Pack Controller StepStick XYZ
+board: bdring-6pack
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: coolstep
+    homing: stallguard
+  steppers:
+    reset: gpio.19
+    pulse: 4
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.33:low
-        tmc2130:
-		6pack-socket1
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.33:low
+  tmc2130:
+    6pack-socket1
 y:
-	limit: gpio.32:low
-	tmc2130:
-		6pack-socket2
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.32:low
+  tmc2130:
+    6pack-socket2
 z:
-	limit: gpio.35:low
-	tmc2130:
-		6pack-socket3
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.35:low
+  tmc2130:
+    6pack-socket3
 a:
-	limit: gpio.34:low
-	tmc2130:
-		6pack-socket4
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.34:low
+  tmc2130:
+    6pack-socket4
 b:
-	limit: gpio.39:low
-	tmc2130:
-		6pack-socket5
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.39:low
+  tmc2130:
+    6pack-socket5
 c:
-	limit: gpio.36:low
-	tmc2130:
-		6pack-socket6
-                rsense: 0.11
-                run: coolstep
-                homing: stallguard
-
-steppers:
-        reset: gpio.19
-        pulse: 4
-
+  limit: gpio.36:low
+  tmc2130:
+    6pack-socket6
 spindle:
-        pwm:
-                output: gpio.26
-                enable: gpio.4
-                direction: gpio.16
+  pwm:
+    output: gpio.26
+    enable: gpio.4
+    direction: gpio.16

--- a/Grbl_Esp32/src/MachineYAML/atari_1020.yaml
+++ b/Grbl_Esp32/src/MachineYAML/atari_1020.yaml
@@ -1,0 +1,63 @@
+name: Atari 1020
+custom-code: Custom/atari_1020.cpp
+x:
+        unipolar:
+                phase0: gpio.13
+                phase1: gpio.21
+                phase2: gpio.16
+                phase3: gpio.22
+        spmm: 10
+        max-rate: 5000
+        acceleration: 500
+        max-travel: 120
+y:
+        unipolar:
+                phase0: gpio.25
+                phase1: gpio.27
+                phase2: gpio.26
+                phase3: gpio.32
+        spmm: 10
+        max-rate: 5000
+        acceleration: 500
+        max-travel: 20000
+z:
+        spmm: 100
+        max-rate: 200000
+        acceleration: 500
+        max-travel: 10
+solenoid:
+        direction: gpio.4
+        pen: gpio.2
+        pwm-frequency: 5000
+        pwm-bits: 8
+        pulse-len: 255
+        pulse-hold: 40
+        duration: 50
+        task-frequency: 50
+
+pens: 4
+pen-change-bumps: 3
+tool-change-z: 5.0
+use-m30: on
+
+reed-switch: gpio.17
+macro:
+        button0: gpio.34
+        button1: gpio.35
+        button2: gpio.36
+steppers:
+        pulse: 3
+        idle: 200
+homing:
+        feed-rate: 3000
+        seek-rate: 3000
+        delay: 250
+        pulloff: 2.0
+
+junction-deviation: 0.01
+arc-tolerance: 0.002
+report-status-mask: 1
+
+invert-limit-pins: on
+
+                

--- a/Grbl_Esp32/src/MachineYAML/atari_1020.yaml
+++ b/Grbl_Esp32/src/MachineYAML/atari_1020.yaml
@@ -1,39 +1,44 @@
 name: Atari 1020
-custom-code: Custom/atari_1020.cpp
+defaults:
+  steppers:
+    pulse: 3
+    idle: 200
+custom:
+  filename: Custom/atari_1020.cpp
 x:
-        unipolar:
-                phase0: gpio.13
-                phase1: gpio.21
-                phase2: gpio.16
-                phase3: gpio.22
-        spmm: 10
-        max-rate: 5000
-        acceleration: 500
-        max-travel: 120
+  unipolar:
+    phase0: gpio.13
+    phase1: gpio.21
+    phase2: gpio.16
+    phase3: gpio.22
+  spmm: 10
+  max-rate: 5000
+  acceleration: 500
+  max-travel: 120
 y:
-        unipolar:
-                phase0: gpio.25
-                phase1: gpio.27
-                phase2: gpio.26
-                phase3: gpio.32
-        spmm: 10
-        max-rate: 5000
-        acceleration: 500
-        max-travel: 20000
+  unipolar:
+    phase0: gpio.25
+    phase1: gpio.27
+    phase2: gpio.26
+    phase3: gpio.32
+  spmm: 10
+  max-rate: 5000
+  acceleration: 500
+  max-travel: 20000
 z:
-        spmm: 100
-        max-rate: 200000
-        acceleration: 500
-        max-travel: 10
+  spmm: 100
+  max-rate: 200000
+  acceleration: 500
+  max-travel: 10
 solenoid:
-        direction: gpio.4
-        pen: gpio.2
-        pwm-frequency: 5000
-        pwm-bits: 8
-        pulse-len: 255
-        pulse-hold: 40
-        duration: 50
-        task-frequency: 50
+  direction: gpio.4
+  pen: gpio.2
+  pwm-frequency: 5000
+  pwm-bits: 8
+  pulse-len: 255
+  pulse-hold: 40
+  duration: 50
+  task-frequency: 50
 
 pens: 4
 pen-change-bumps: 3
@@ -42,17 +47,14 @@ use-m30: on
 
 reed-switch: gpio.17
 macro:
-        button0: gpio.34
-        button1: gpio.35
-        button2: gpio.36
-steppers:
-        pulse: 3
-        idle: 200
+  button0: gpio.34
+  button1: gpio.35
+  button2: gpio.36
 homing:
-        feed-rate: 3000
-        seek-rate: 3000
-        delay: 250
-        pulloff: 2.0
+  feed-rate: 3000
+  seek-rate: 3000
+  delay: 250
+  pulloff: 2.0
 
 junction-deviation: 0.01
 arc-tolerance: 0.002
@@ -60,4 +62,4 @@ report-status-mask: 1
 
 invert-limit-pins: on
 
-                
+    

--- a/Grbl_Esp32/src/MachineYAML/atari_1020.yaml
+++ b/Grbl_Esp32/src/MachineYAML/atari_1020.yaml
@@ -5,6 +5,19 @@ defaults:
     idle: 200
 custom:
   filename: Custom/atari_1020.cpp
+  solenoid:
+    direction: gpio.4
+    pen: gpio.2
+    pwm-frequency: 5000
+    pwm-bits: 8
+    pulse-len: 255
+    pulse-hold: 40
+    duration: 50
+    task-frequency: 50
+  pens: 4
+  pen-change-bumps: 3
+  tool-change-z: 5.0
+  reed-switch: gpio.17
 x:
   unipolar:
     phase0: gpio.13
@@ -30,36 +43,18 @@ z:
   max-rate: 200000
   acceleration: 500
   max-travel: 10
-solenoid:
-  direction: gpio.4
-  pen: gpio.2
-  pwm-frequency: 5000
-  pwm-bits: 8
-  pulse-len: 255
-  pulse-hold: 40
-  duration: 50
-  task-frequency: 50
 
-pens: 4
-pen-change-bumps: 3
-tool-change-z: 5.0
-use-m30: on
-
-reed-switch: gpio.17
 macro:
-  button0: gpio.34
-  button1: gpio.35
-  button2: gpio.36
+  - gpio.34
+  - gpio.35
+  - gpio.36
 homing:
   feed-rate: 3000
   seek-rate: 3000
   delay: 250
   pulloff: 2.0
 
-junction-deviation: 0.01
-arc-tolerance: 0.002
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
 report-status-mask: 1
-
-invert-limit-pins: on
-
-    

--- a/Grbl_Esp32/src/MachineYAML/bigtest.yaml
+++ b/Grbl_Esp32/src/MachineYAML/bigtest.yaml
@@ -1,39 +1,38 @@
 ---
 name: 6 Pack StepStick XYYZ SW_XYZP
+board: bdring-6pack
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: coolstep
+    homing: stallguard
+  steppers:
+    reset: gpio.19
+    pulse: 4
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.33:low
-        tmc2130:
-		6pack-socket1
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.33:low
+  tmc2130:
+    6pack-socket1
 y:
-	limit: gpio.32:low
-	stepstick:
-		6pack-socket2
+  limit: gpio.32:low
+  stepstick:
+    6pack-socket2
 z:
-	limit: gpio.35:low
-	tmc2130:
-		6pack-socket3
-		rsense: 0.11
-		run: coolstep
-		homing: stallguard
+  limit: gpio.35:low
+  tmc2130:
+    6pack-socket3
 a:
-	dynamixel:
-                RxD: gpio.26
-                RTS: gpio.4
-                TxD: gpio.16
-                protocol: 1
+  dynamixel:
+    RxD: gpio.26
+    RTS: gpio.4
+    TxD: gpio.16
+    protocol: 1
 b:
-	rcservo:
-                pin: gpio.27
-                min: 1.0
-                max: 1.0
-
-steppers:
-        reset: gpio.19
-        pulse: 4
+  rcservo:
+    pin: gpio.27
+    min: 1.0
+    max: 1.0

--- a/Grbl_Esp32/src/MachineYAML/bigtest.yaml
+++ b/Grbl_Esp32/src/MachineYAML/bigtest.yaml
@@ -1,0 +1,39 @@
+---
+name: 6 Pack StepStick XYYZ SW_XYZP
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+x:
+        limit: gpio.33:low
+        tmc2130:
+		6pack-socket1
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+y:
+	limit: gpio.32:low
+	stepstick:
+		6pack-socket2
+z:
+	limit: gpio.35:low
+	tmc2130:
+		6pack-socket3
+		rsense: 0.11
+		run: coolstep
+		homing: stallguard
+a:
+	dynamixel:
+                RxD: gpio.26
+                RTS: gpio.4
+                TxD: gpio.16
+                protocol: 1
+b:
+	rcservo:
+                pin: gpio.27
+                min: 1.0
+                max: 1.0
+
+steppers:
+        reset: gpio.19
+        pulse: 4

--- a/Grbl_Esp32/src/MachineYAML/coolant_test.yaml
+++ b/Grbl_Esp32/src/MachineYAML/coolant_test.yaml
@@ -1,4 +1,5 @@
 ---
 name: Coolant Test
-mist: gpio.21
-flood: gpio.25
+coolant:
+  mist: gpio.21
+  flood: gpio.25

--- a/Grbl_Esp32/src/MachineYAML/coolant_test.yaml
+++ b/Grbl_Esp32/src/MachineYAML/coolant_test.yaml
@@ -1,0 +1,4 @@
+---
+name: Coolant Test
+mist: gpio.21
+flood: gpio.25

--- a/Grbl_Esp32/src/MachineYAML/esp32_printer_controller.yaml
+++ b/Grbl_Esp32/src/MachineYAML/esp32_printer_controller.yaml
@@ -1,0 +1,34 @@
+---
+name: ESP32 Printer Controller
+custom-code: Custom/esp32_printer_controller.cpp
+i2s0:
+        bits: 16
+        stream: on
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+
+debounce: 100
+
+homing:
+        feed-rate: 200
+        seek-rate: 1000
+        debounce: 250
+        pulloff: 3
+        cycle0: x
+
+steppers:
+        pulse: 4
+
+x:
+        step: i2so.9
+        direction: i2s0.7
+y:
+        step: i2so.5
+        direction: i2s0.4
+z:
+        step: i2so.2
+        direction: i2s0.1
+a:
+        step: i2so.12
+        direction: i2s0.13

--- a/Grbl_Esp32/src/MachineYAML/esp32_printer_controller.yaml
+++ b/Grbl_Esp32/src/MachineYAML/esp32_printer_controller.yaml
@@ -1,34 +1,36 @@
 ---
 name: ESP32 Printer Controller
-custom-code: Custom/esp32_printer_controller.cpp
+board: wmb-esp32-printer-controller
+custom:
+  filename: Custom/esp32_printer_controller.cpp
+defaults:
+  steppers:
+    pulse: 4
 i2s0:
-        bits: 16
-        stream: on
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
+  bits: 16
+  stream: on
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 
 debounce: 100
 
 homing:
-        feed-rate: 200
-        seek-rate: 1000
-        debounce: 250
-        pulloff: 3
-        cycle0: x
-
-steppers:
-        pulse: 4
-
+  feed-rate: 200
+  seek-rate: 1000
+  debounce: 250
+  pulloff: 3
+  cycles:
+    - x
 x:
-        step: i2so.9
-        direction: i2s0.7
+  step: i2so.9
+  direction: i2s0.7
 y:
-        step: i2so.5
-        direction: i2s0.4
+  step: i2so.5
+  direction: i2s0.4
 z:
-        step: i2so.2
-        direction: i2s0.1
+  step: i2so.2
+  direction: i2s0.1
 a:
-        step: i2so.12
-        direction: i2s0.13
+  step: i2so.12
+  direction: i2s0.13

--- a/Grbl_Esp32/src/MachineYAML/esp32_printer_controller.yaml
+++ b/Grbl_Esp32/src/MachineYAML/esp32_printer_controller.yaml
@@ -6,19 +6,19 @@ custom:
 defaults:
   steppers:
     pulse: 4
-i2s0:
+  gpio:
+    debounce: 250
+    
+i2so:
   bits: 16
   stream: on
   bck: gpio.22
   ws: gpio.17
   data: gpio.21
 
-debounce: 100
-
 homing:
   feed-rate: 200
   seek-rate: 1000
-  debounce: 250
   pulloff: 3
   cycles:
     - x

--- a/Grbl_Esp32/src/MachineYAML/espduino.yaml
+++ b/Grbl_Esp32/src/MachineYAML/espduino.yaml
@@ -20,11 +20,11 @@ spindle:
   pwm:
     output: gpio.19
     direction: gpio.18
-
-mist: gpio.36
-flood: gpio.34
+coolant:
+  mist: gpio.36
+  flood: gpio.34
 probe: gpio.39
-
-reset: gpio.2:low
-feed-hold: gpio.4:low
-cycle-start: gpio.35:low
+control:
+  reset: gpio.2:low
+  feed-hold: gpio.4:low
+  cycle-start: gpio.35:low

--- a/Grbl_Esp32/src/MachineYAML/espduino.yaml
+++ b/Grbl_Esp32/src/MachineYAML/espduino.yaml
@@ -1,26 +1,25 @@
 ---
 name: ESPDUINO_32
-
+board: espduino
+defaults:
+  steppers:
+    disable: gpio.12
 x:
-        stepstick:
-                step: gpio.26
-                direction: gpio.16
+  stepstick:
+    step: gpio.26
+    direction: gpio.16
 y:
-        stepstick:
-                step: gpio.25
-                direction: gpio.27
+  stepstick:
+    step: gpio.25
+    direction: gpio.27
 z:
-        stepstick:
-                step: gpio.17
-                direction: gpio.14
-
-steppers:
-        disable: gpio.12
-
+  stepstick:
+    step: gpio.17
+    direction: gpio.14
 spindle:
-        pwm:
-                output: gpio.19
-                direction: gpio.18
+  pwm:
+    output: gpio.19
+    direction: gpio.18
 
 mist: gpio.36
 flood: gpio.34

--- a/Grbl_Esp32/src/MachineYAML/espduino.yaml
+++ b/Grbl_Esp32/src/MachineYAML/espduino.yaml
@@ -1,0 +1,31 @@
+---
+name: ESPDUINO_32
+
+x:
+        stepstick:
+                step: gpio.26
+                direction: gpio.16
+y:
+        stepstick:
+                step: gpio.25
+                direction: gpio.27
+z:
+        stepstick:
+                step: gpio.17
+                direction: gpio.14
+
+steppers:
+        disable: gpio.12
+
+spindle:
+        pwm:
+                output: gpio.19
+                direction: gpio.18
+
+mist: gpio.36
+flood: gpio.34
+probe: gpio.39
+
+reset: gpio.2:low
+feed-hold: gpio.4:low
+cycle-start: gpio.35:low

--- a/Grbl_Esp32/src/MachineYAML/i2s_out_xxyyzz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/i2s_out_xxyyzz.yaml
@@ -1,39 +1,41 @@
 ---
 name: ESP32 I2S XXYYZZ Axis Driver Board (StepStick)
+board: bdring-6pack
+defaults:
+  steppers:
+    ms1: gpio.23
+    ms2: gpio.18
+    reset: gpio.19
+    pulse: 4
 sdcard: off
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
-steppers:
-        ms1: gpio.23
-        ms2: gpio.18
-        reset: gpio.19
-        pulse: 4
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.36:low
-        stepstick:
-                6pack-socket1
+  limit: gpio.36:low
+  stepstick:
+    6pack-socket1
 x2:
-        stepstick:
-                6pack-socket2
+  stepstick:
+    6pack-socket2
 y:
-        limit: gpio.39:low
-        stepstick:
-                6pack-socket3
+  limit: gpio.39:low
+  stepstick:
+    6pack-socket3
 y2:
-        stepstick:
-                6pack-socket4
+  stepstick:
+    6pack-socket4
 z:
-        limit: gpio.34:low
-        stepstick:
-                6pack-socket5
+  limit: gpio.34:low
+  stepstick:
+    6pack-socket5
 z2:
-        stepstick:
-                6pack-socket6
+  stepstick:
+    6pack-socket6
 spindle:
-        pwm:
-                output: gpio.26
-                enable: gpio.4
-                direction: gpio.16
+  pwm:
+    output: gpio.26
+    enable: gpio.4
+    direction: gpio.16
 probe: gpio.25

--- a/Grbl_Esp32/src/MachineYAML/i2s_out_xxyyzz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/i2s_out_xxyyzz.yaml
@@ -1,0 +1,39 @@
+---
+name: ESP32 I2S XXYYZZ Axis Driver Board (StepStick)
+sdcard: off
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+steppers:
+        ms1: gpio.23
+        ms2: gpio.18
+        reset: gpio.19
+        pulse: 4
+x:
+        limit: gpio.36:low
+        stepstick:
+                6pack-socket1
+x2:
+        stepstick:
+                6pack-socket2
+y:
+        limit: gpio.39:low
+        stepstick:
+                6pack-socket3
+y2:
+        stepstick:
+                6pack-socket4
+z:
+        limit: gpio.34:low
+        stepstick:
+                6pack-socket5
+z2:
+        stepstick:
+                6pack-socket6
+spindle:
+        pwm:
+                output: gpio.26
+                enable: gpio.4
+                direction: gpio.16
+probe: gpio.25

--- a/Grbl_Esp32/src/MachineYAML/i2s_out_xyxabc.yaml
+++ b/Grbl_Esp32/src/MachineYAML/i2s_out_xyxabc.yaml
@@ -1,42 +1,44 @@
 ---
 name: ESP32 I2S 6 Axis Driver Board (StepStick)
+board: bdring-6pack
+defaults:
+  steppers:
+    ms1: gpio.23
+    ms2: gpio.18
+    reset: gpio.19
+    pulse: 4
 sdcard: off
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
-steppers:
-        ms1: gpio.23
-        ms2: gpio.18
-        reset: gpio.19
-        pulse: 4
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.36:low
-        stepstick:
-                6pack-socket1
+  limit: gpio.36:low
+  stepstick:
+    6pack-socket1
 y:
-        limit: gpio.39:low
-        stepstick:
-                6pack-socket2
+  limit: gpio.39:low
+  stepstick:
+    6pack-socket2
 z:
-        limit: gpio.34:low
-        stepstick:
-                6pack-socket3
+  limit: gpio.34:low
+  stepstick:
+    6pack-socket3
 a:
-        limit: gpio.35:low
-        stepstick:
-                6pack-socket4
+  limit: gpio.35:low
+  stepstick:
+    6pack-socket4
 b:
-        limit: gpio.32:low
-                stepstick:
-                6pack-socket5
+  limit: gpio.32:low
+    stepstick:
+    6pack-socket5
 c:
-        limit: gpio.33:low
-        stepstick:
-                6pack-socket6
+  limit: gpio.33:low
+  stepstick:
+    6pack-socket6
 spindle:
-        pwm:
-                output: gpio.26
-                enable: gpio.4
-                direction: gpio.16
+  pwm:
+    output: gpio.26
+    enable: gpio.4
+    direction: gpio.16
 probe: gpio.25

--- a/Grbl_Esp32/src/MachineYAML/i2s_out_xyxabc.yaml
+++ b/Grbl_Esp32/src/MachineYAML/i2s_out_xyxabc.yaml
@@ -1,0 +1,42 @@
+---
+name: ESP32 I2S 6 Axis Driver Board (StepStick)
+sdcard: off
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+steppers:
+        ms1: gpio.23
+        ms2: gpio.18
+        reset: gpio.19
+        pulse: 4
+x:
+        limit: gpio.36:low
+        stepstick:
+                6pack-socket1
+y:
+        limit: gpio.39:low
+        stepstick:
+                6pack-socket2
+z:
+        limit: gpio.34:low
+        stepstick:
+                6pack-socket3
+a:
+        limit: gpio.35:low
+        stepstick:
+                6pack-socket4
+b:
+        limit: gpio.32:low
+                stepstick:
+                6pack-socket5
+c:
+        limit: gpio.33:low
+        stepstick:
+                6pack-socket6
+spindle:
+        pwm:
+                output: gpio.26
+                enable: gpio.4
+                direction: gpio.16
+probe: gpio.25

--- a/Grbl_Esp32/src/MachineYAML/i2s_out_xyzabc_trinamic.yaml
+++ b/Grbl_Esp32/src/MachineYAML/i2s_out_xyzabc_trinamic.yaml
@@ -1,55 +1,43 @@
 ---
 name: ESP32 SPI 6 Axis Driver Board Trinamic
+board: bdring-6pack
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: coolstep
+    homing: coolstep
+  steppers:
+    pulse: 4
 i2so:
-        bck: gpio.22
-        ws: gpio.17
-        data: gpio.21
-steppers:
-        pulse: 4
+  bck: gpio.22
+  ws: gpio.17
+  data: gpio.21
 x:
-        limit: gpio.33:low
-        tmc2130:
-                6pack-socket1
-                run: coolstep
-                hold: coolstep
-                rsense: 0.11
+  limit: gpio.33:low
+  tmc2130:
+    6pack-socket1
 y:
-        limit: gpio.32:low
-        tmc2130:
-                6pack-socket2
-                run: coolstep
-                hold: coolstep
-                rsense: 0.11
+  limit: gpio.32:low
+  tmc2130:
+    6pack-socket2
 z:
-        limit: gpio.35:low
-        tmc2130:
-                6pack-socket3
-                run: coolstep
-                hold: coolstep
-                rsense: 0.11
+  limit: gpio.35:low
+  tmc2130:
+    6pack-socket3
 a:
-        limit: gpio.34:low
-        tmc2130:
-                6pack-socket4
-                run: coolstep
-                hold: coolstep
-                rsense: 0.11
+  limit: gpio.34:low
+  tmc2130:
+    6pack-socket4
 b:
-        limit: gpio.39:low
-                tmc2130:
-                6pack-socket5
-                run: coolstep
-                hold: coolstep
-                rsense: 0.11
+  limit: gpio.39:low
+    tmc2130:
+    6pack-socket5
 c:
-        limit: gpio.36:low
-        tmc2130:
-                6pack-socket6
-                run: coolstep
-                hold: coolstep
-                rsense: 0.11
+  limit: gpio.36:low
+  tmc2130:
+    6pack-socket6
 spindle:
-        relay:
-                output: gpio.26
+  relay:
+    output: gpio.26
 probe: gpio.25
 mist: gpio.2

--- a/Grbl_Esp32/src/MachineYAML/i2s_out_xyzabc_trinamic.yaml
+++ b/Grbl_Esp32/src/MachineYAML/i2s_out_xyzabc_trinamic.yaml
@@ -1,0 +1,55 @@
+---
+name: ESP32 SPI 6 Axis Driver Board Trinamic
+i2so:
+        bck: gpio.22
+        ws: gpio.17
+        data: gpio.21
+steppers:
+        pulse: 4
+x:
+        limit: gpio.33:low
+        tmc2130:
+                6pack-socket1
+                run: coolstep
+                hold: coolstep
+                rsense: 0.11
+y:
+        limit: gpio.32:low
+        tmc2130:
+                6pack-socket2
+                run: coolstep
+                hold: coolstep
+                rsense: 0.11
+z:
+        limit: gpio.35:low
+        tmc2130:
+                6pack-socket3
+                run: coolstep
+                hold: coolstep
+                rsense: 0.11
+a:
+        limit: gpio.34:low
+        tmc2130:
+                6pack-socket4
+                run: coolstep
+                hold: coolstep
+                rsense: 0.11
+b:
+        limit: gpio.39:low
+                tmc2130:
+                6pack-socket5
+                run: coolstep
+                hold: coolstep
+                rsense: 0.11
+c:
+        limit: gpio.36:low
+        tmc2130:
+                6pack-socket6
+                run: coolstep
+                hold: coolstep
+                rsense: 0.11
+spindle:
+        relay:
+                output: gpio.26
+probe: gpio.25
+mist: gpio.2

--- a/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_pwm.yaml
+++ b/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_pwm.yaml
@@ -1,0 +1,40 @@
+---
+name: LOWRIDER YYZZX V1P2
+
+x:
+        limit: gpio.15:low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+y2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+z:
+        limit: 17:low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+z2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+
+steppers:
+        disable: gpio.13
+
+spindle:
+        pwm:
+                output: gpio.16
+                enable: gpio.32
+debounce: on
+
+probe: gpio.35
+reset: gpio.34
+feed-hold: gpio.36
+cycle-start: gpio.39

--- a/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_pwm.yaml
+++ b/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_pwm.yaml
@@ -1,37 +1,36 @@
 ---
 name: LOWRIDER YYZZX V1P2
-
+board: bdring-lowrider-v1p2
+defaults:
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.15:low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
+  limit: gpio.15:low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
 y2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 z:
-        limit: 17:low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
+  limit: 17:low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
 z2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
-
-steppers:
-        disable: gpio.13
-
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 spindle:
-        pwm:
-                output: gpio.16
-                enable: gpio.32
+  pwm:
+    output: gpio.16
+    enable: gpio.32
 debounce: on
 
 probe: gpio.35

--- a/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_pwm.yaml
+++ b/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_pwm.yaml
@@ -4,6 +4,9 @@ board: bdring-lowrider-v1p2
 defaults:
   steppers:
     disable: gpio.13
+  gpio:
+    debounce: 100
+
 x:
   limit: gpio.15:low
   stepstick:
@@ -31,9 +34,9 @@ spindle:
   pwm:
     output: gpio.16
     enable: gpio.32
-debounce: on
 
 probe: gpio.35
-reset: gpio.34
-feed-hold: gpio.36
-cycle-start: gpio.39
+control:
+  reset: gpio.34
+  feed-hold: gpio.36
+  cycle-start: gpio.39

--- a/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_relay.yaml
@@ -1,36 +1,35 @@
 ---
 name: LOWRIDER YYZZX V1P2
-
+board: bdring-lowrider-v1p2
+defaults:
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.15:low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
+  limit: gpio.15:low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
 y2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 z:
-        limit: 17:low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
+  limit: 17:low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
 z2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
-
-steppers:
-        disable: gpio.13
-
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 spindle:
-        relay:
-                output: gpio.2
+  relay:
+    output: gpio.2
 debounce: on
 
 probe: gpio.35

--- a/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_relay.yaml
@@ -4,6 +4,8 @@ board: bdring-lowrider-v1p2
 defaults:
   steppers:
     disable: gpio.13
+  debounce: 100
+
 x:
   limit: gpio.15:low
   stepstick:
@@ -30,9 +32,8 @@ z2:
 spindle:
   relay:
     output: gpio.2
-debounce: on
-
-probe: gpio.35
-reset: gpio.34
-feed-hold: gpio.36
-cycle-start: gpio.39
+control:
+  probe: gpio.35
+  reset: gpio.34
+  feed-hold: gpio.36
+  cycle-start: gpio.39

--- a/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/lowrider_v1p2_relay.yaml
@@ -1,0 +1,39 @@
+---
+name: LOWRIDER YYZZX V1P2
+
+x:
+        limit: gpio.15:low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+y2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+z:
+        limit: 17:low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+z2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+
+steppers:
+        disable: gpio.13
+
+spindle:
+        relay:
+                output: gpio.2
+debounce: on
+
+probe: gpio.35
+reset: gpio.34
+feed-hold: gpio.36
+cycle-start: gpio.39

--- a/Grbl_Esp32/src/MachineYAML/midtbot.yaml
+++ b/Grbl_Esp32/src/MachineYAML/midtbot.yaml
@@ -1,0 +1,44 @@
+---
+name: MIDTBOT
+x:
+        limit: gpio.2:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        homing: invert
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 100
+y:
+        limit: gpio.4,low
+        stepstick:
+                step: gpio.14:low
+                direction: gpio.25
+        spmm: 100
+        max-rate: 8000
+        acceleration: 200
+        travel: 100
+z:
+        servo:
+                pin: gpio.27
+        spmm: 100
+        max-rate: 5000
+        acceleration: 100
+        travel: 100
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+homing:
+        cycle0: y
+        cycle1: x
+        feed-rate: 200
+        seek-rate: 1000
+        debounce: 250
+        pulloff: 3
+
+status-report-mask: 1
+junction-deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0

--- a/Grbl_Esp32/src/MachineYAML/midtbot.yaml
+++ b/Grbl_Esp32/src/MachineYAML/midtbot.yaml
@@ -6,6 +6,8 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 x:
   limit: gpio.2:low
   stepstick:
@@ -38,10 +40,10 @@ homing:
     - x
   feed-rate: 200
   seek-rate: 1000
-  debounce: 250
   pulloff: 3
-
-status-report-mask: 1
-junction-deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002

--- a/Grbl_Esp32/src/MachineYAML/midtbot.yaml
+++ b/Grbl_Esp32/src/MachineYAML/midtbot.yaml
@@ -1,42 +1,45 @@
 ---
 name: MIDTBOT
+board: bdring-midtbot
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 x:
-        limit: gpio.2:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        homing: invert
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 100
+  limit: gpio.2:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  homing: invert
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 100
 y:
-        limit: gpio.4,low
-        stepstick:
-                step: gpio.14:low
-                direction: gpio.25
-        spmm: 100
-        max-rate: 8000
-        acceleration: 200
-        travel: 100
+  limit: gpio.4,low
+  stepstick:
+    step: gpio.14:low
+    direction: gpio.25
+  spmm: 100
+  max-rate: 8000
+  acceleration: 200
+  travel: 100
 z:
-        servo:
-                pin: gpio.27
-        spmm: 100
-        max-rate: 5000
-        acceleration: 100
-        travel: 100
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  servo:
+    pin: gpio.27
+  spmm: 100
+  max-rate: 5000
+  acceleration: 100
+  travel: 100
 homing:
-        cycle0: y
-        cycle1: x
-        feed-rate: 200
-        seek-rate: 1000
-        debounce: 250
-        pulloff: 3
+  cycle:
+    - y
+    - x
+  feed-rate: 200
+  seek-rate: 1000
+  debounce: 250
+  pulloff: 3
 
 status-report-mask: 1
 junction-deviation: 0.01

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_laser_module_v1p2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_laser_module_v1p2.yaml
@@ -6,9 +6,12 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 100
+
 custom:
   filename: Custom/mpcnc_laser_module.cpp
-level-shift: gpio.32
+  level-shift: gpio.32
 homing:
   squared: xy
 x:
@@ -52,16 +55,16 @@ spindle:
     rpm-min: 0.0
 
 mist: gpio.2
-debounce: on
 
 probe: gpio.35
-
-reset: gpio.34,low
-feed-hold: gpio.36,low
-cycle-start: gpio.39,low
-
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+control:
+  reset: gpio.34,low
+  feed-hold: gpio.36,low
+  cycle-start: gpio.39,low
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_laser_module_v1p2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_laser_module_v1p2.yaml
@@ -1,53 +1,55 @@
 ---
 name: MPCNC_V1P2 with Laser Module
-custom-code: Custom/mpcnc_laser_module.cpp
+board: bdring-mpcnc-v1p2
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
+custom:
+  filename: Custom/mpcnc_laser_module.cpp
 level-shift: gpio.32
 homing:
-        squared: xy
+  squared: xy
 x:
-        limit: gpio.17,low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
+  limit: gpio.17,low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
 x2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 y:
-        limit: gpio.4,low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
+  limit: gpio.4,low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
 y2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 z:
-        limit: gpio.15,low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 800
-        max-rate: 3000
-        acceleration: 100
-        travel: 80
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15,low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 800
+  max-rate: 3000
+  acceleration: 100
+  travel: 80
 spindle:
-        pwm:
-                output: gpio.16
-                rpm-min: 0.0
+  pwm:
+    output: gpio.16
+    rpm-min: 0.0
 
 mist: gpio.2
 debounce: on

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_laser_module_v1p2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_laser_module_v1p2.yaml
@@ -1,0 +1,65 @@
+---
+name: MPCNC_V1P2 with Laser Module
+custom-code: Custom/mpcnc_laser_module.cpp
+level-shift: gpio.32
+homing:
+        squared: xy
+x:
+        limit: gpio.17,low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+x2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+y:
+        limit: gpio.4,low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+y2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+z:
+        limit: gpio.15,low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 800
+        max-rate: 3000
+        acceleration: 100
+        travel: 80
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+spindle:
+        pwm:
+                output: gpio.16
+                rpm-min: 0.0
+
+mist: gpio.2
+debounce: on
+
+probe: gpio.35
+
+reset: gpio.34,low
+feed-hold: gpio.36,low
+cycle-start: gpio.39,low
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1.yaml
@@ -6,11 +6,12 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 homing:
   squared: xy
   feed-rate: 100
   seek-rate: 200
-  debounce: 250
   pulloff: 2
 x:
   limit: gpio.2,low
@@ -58,12 +59,14 @@ spindle:
 
 probe: gpio.35
 
-reset: gpio.34,low
-feed-hold: gpio.36,low
-cycle-start: gpio.39,low
-
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+control:
+  reset: gpio.34,low
+  feed-hold: gpio.36,low
+  cycle-start: gpio.39,low
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction_deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1.yaml
@@ -1,59 +1,60 @@
 ---
 name: MPCNC_V1P1
+board: bdring-mpcnc-v1p1
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 homing:
-        squared: xy
-        feed-rate: 100
-        seek-rate: 200
-        debounce: 250
-        pulloff: 2
+  squared: xy
+  feed-rate: 100
+  seek-rate: 200
+  debounce: 250
+  pulloff: 2
 x:
-        limit: gpio.2,low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.2,low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 x2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 y:
-        limit: gpio.4,low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.4,low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 y2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 z:
-        limit: gpio.15,low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 800
-        max-rate: 3000
-        acceleration: 100
-        travel: 80
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15,low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 800
+  max-rate: 3000
+  acceleration: 100
+  travel: 80
 spindle:
-        pwm:
-                output: gpio.16
-                enable: gpio.32
-                rpm-min: 0
-                rpm-max: 1000
+  pwm:
+    output: gpio.16
+    enable: gpio.32
+    rpm-min: 0
+    rpm-max: 1000
 
 probe: gpio.35
 

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1.yaml
@@ -1,0 +1,68 @@
+---
+name: MPCNC_V1P1
+homing:
+        squared: xy
+        feed-rate: 100
+        seek-rate: 200
+        debounce: 250
+        pulloff: 2
+x:
+        limit: gpio.2,low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+x2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+y:
+        limit: gpio.4,low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+y2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+z:
+        limit: gpio.15,low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 800
+        max-rate: 3000
+        acceleration: 100
+        travel: 80
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+spindle:
+        pwm:
+                output: gpio.16
+                enable: gpio.32
+                rpm-min: 0
+                rpm-max: 1000
+
+probe: gpio.35
+
+reset: gpio.34,low
+feed-hold: gpio.36,low
+cycle-start: gpio.39,low
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1_relay.yaml
@@ -1,58 +1,59 @@
 ---
 name: MPCNC_V1P1
+board: bdring-mpcnc-v1p1
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 homing:
-        squared: xy
-        feed-rate: 100
-        seek-rate: 200
-        debounce: 250
-        pulloff: 2
+  squared: xy
+  feed-rate: 100
+  seek-rate: 200
+  debounce: 250
+  pulloff: 2
 x:
-        limit: gpio.2,low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.2,low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 x2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 y:
-        limit: gpio.4,low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.4,low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 y2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 z:
-        limit: gpio.15,low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 800
-        max-rate: 3000
-        acceleration: 100
-        travel: 80
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15,low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 800
+  max-rate: 3000
+  acceleration: 100
+  travel: 80
 spindle:
-        relay:
-                output: gpio.17
-                rpm-min: 0
-                rpm-max: 1
+  relay:
+    output: gpio.17
+    rpm-min: 0
+    rpm-max: 1
 probe: gpio.35
 
 reset: gpio.34,low

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1_relay.yaml
@@ -1,0 +1,66 @@
+---
+name: MPCNC_V1P1
+homing:
+        squared: xy
+        feed-rate: 100
+        seek-rate: 200
+        debounce: 250
+        pulloff: 2
+x:
+        limit: gpio.2,low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+x2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+y:
+        limit: gpio.4,low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+y2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+z:
+        limit: gpio.15,low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 800
+        max-rate: 3000
+        acceleration: 100
+        travel: 80
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+spindle:
+        relay:
+                output: gpio.17
+                rpm-min: 0
+                rpm-max: 1
+probe: gpio.35
+
+reset: gpio.34,low
+feed-hold: gpio.36,low
+cycle-start: gpio.39,low
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p1_relay.yaml
@@ -6,11 +6,12 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 homing:
   squared: xy
   feed-rate: 100
   seek-rate: 200
-  debounce: 250
   pulloff: 2
 x:
   limit: gpio.2,low
@@ -56,12 +57,14 @@ spindle:
     rpm-max: 1
 probe: gpio.35
 
-reset: gpio.34,low
-feed-hold: gpio.36,low
-cycle-start: gpio.39,low
-
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+control:
+  reset: gpio.34,low
+  feed-hold: gpio.36,low
+  cycle-start: gpio.39,low
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2.yaml
@@ -1,0 +1,70 @@
+---
+name: MPCNC_V1P2
+homing:
+        squared: xy
+        feed-rate: 100
+        seek-rate: 200
+        debounce: 250
+        pulloff: 2
+x:
+        limit: gpio.17,low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+x2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+y:
+        limit: gpio.4,low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+y2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+z:
+        limit: gpio.15,low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 800
+        max-rate: 3000
+        acceleration: 100
+        travel: 80
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+spindle:
+        pwm:
+                output: gpio.16
+                enable: gpio.32
+                rpm-min: 0
+                rpm-max: 1000
+
+debounce: on
+
+probe: gpio.35
+
+reset: gpio.34,low
+feed-hold: gpio.36,low
+cycle-start: gpio.39,low
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2.yaml
@@ -1,59 +1,60 @@
 ---
 name: MPCNC_V1P2
+board: bdring-mpcnc-v1p2
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 homing:
-        squared: xy
-        feed-rate: 100
-        seek-rate: 200
-        debounce: 250
-        pulloff: 2
+  squared: xy
+  feed-rate: 100
+  seek-rate: 200
+  debounce: 250
+  pulloff: 2
 x:
-        limit: gpio.17,low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.17,low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 x2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 y:
-        limit: gpio.4,low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.4,low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 y2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 z:
-        limit: gpio.15,low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 800
-        max-rate: 3000
-        acceleration: 100
-        travel: 80
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15,low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 800
+  max-rate: 3000
+  acceleration: 100
+  travel: 80
 spindle:
-        pwm:
-                output: gpio.16
-                enable: gpio.32
-                rpm-min: 0
-                rpm-max: 1000
+  pwm:
+    output: gpio.16
+    enable: gpio.32
+    rpm-min: 0
+    rpm-max: 1000
 
 debounce: on
 

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2.yaml
@@ -6,11 +6,12 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 homing:
   squared: xy
   feed-rate: 100
   seek-rate: 200
-  debounce: 250
   pulloff: 2
 x:
   limit: gpio.17,low
@@ -55,17 +56,17 @@ spindle:
     enable: gpio.32
     rpm-min: 0
     rpm-max: 1000
-
-debounce: on
-
 probe: gpio.35
 
-reset: gpio.34,low
-feed-hold: gpio.36,low
-cycle-start: gpio.39,low
+control:
+  reset: gpio.34,low
+  feed-hold: gpio.36,low
+  cycle-start: gpio.39,low
 
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2_relay.yaml
@@ -1,58 +1,59 @@
 ---
 name: MPCNC_V1P2
+board: bdring-mpcnc-v1p2
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 homing:
-        squared: xy
-        feed-rate: 100
-        seek-rate: 200
-        debounce: 250
-        pulloff: 2
+  squared: xy
+  feed-rate: 100
+  seek-rate: 200
+  debounce: 250
+  pulloff: 2
 x:
-        limit: gpio.17,low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.17,low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 x2:
-        stepstick:
-                step: gpio.22
-                direction: gpio.26
+  stepstick:
+    step: gpio.22
+    direction: gpio.26
 y:
-        limit: gpio.4,low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 200
-        max-rate: 8000
-        acceleration: 200
-        travel: 500
-        homing: negative
+  limit: gpio.4,low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 200
+  max-rate: 8000
+  acceleration: 200
+  travel: 500
+  homing: negative
 y2:
-        stepstick:
-                step: gpio.21
-                direction: gpio.25
+  stepstick:
+    step: gpio.21
+    direction: gpio.25
 z:
-        limit: gpio.15,low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 800
-        max-rate: 3000
-        acceleration: 100
-        travel: 80
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15,low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 800
+  max-rate: 3000
+  acceleration: 100
+  travel: 80
 spindle:
-        relay:
-                output: gpio.2
-                rpm-min: 0
-                rpm-max: 1
+  relay:
+    output: gpio.2
+    rpm-min: 0
+    rpm-max: 1
 
 debounce: on
 

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2_relay.yaml
@@ -6,11 +6,12 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 homing:
   squared: xy
   feed-rate: 100
   seek-rate: 200
-  debounce: 250
   pulloff: 2
 x:
   limit: gpio.17,low
@@ -55,16 +56,17 @@ spindle:
     rpm-min: 0
     rpm-max: 1
 
-debounce: on
-
 probe: gpio.35
 
-reset: gpio.34,low
-feed-hold: gpio.36,low
-cycle-start: gpio.39,low
+control:
+  reset: gpio.34,low
+  feed-hold: gpio.36,low
+  cycle-start: gpio.39,low
 
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2_relay.yaml
+++ b/Grbl_Esp32/src/MachineYAML/mpcnc_v1p2_relay.yaml
@@ -1,0 +1,69 @@
+---
+name: MPCNC_V1P2
+homing:
+        squared: xy
+        feed-rate: 100
+        seek-rate: 200
+        debounce: 250
+        pulloff: 2
+x:
+        limit: gpio.17,low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+x2:
+        stepstick:
+                step: gpio.22
+                direction: gpio.26
+y:
+        limit: gpio.4,low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 200
+        max-rate: 8000
+        acceleration: 200
+        travel: 500
+        homing: negative
+y2:
+        stepstick:
+                step: gpio.21
+                direction: gpio.25
+z:
+        limit: gpio.15,low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 800
+        max-rate: 3000
+        acceleration: 100
+        travel: 80
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+spindle:
+        relay:
+                output: gpio.2
+                rpm-min: 0
+                rpm-max: 1
+
+debounce: on
+
+probe: gpio.35
+
+reset: gpio.34,low
+feed-hold: gpio.36,low
+cycle-start: gpio.39,low
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/pen_laser_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/pen_laser_v1.yaml
@@ -1,0 +1,46 @@
+---
+name: PEN_LASER_V2
+homing:
+        feed-rate: 200
+        seek-rate: 1000
+        debounce: 250
+        pulloff: 3
+x:
+        limit: gpio.2:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 80
+        max-rate: 5000
+        acceleration: 50
+        travel: 300
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 80
+        max-rate: 5000
+        acceleration: 50
+        travel: 300
+z:
+        limit: gpio.15:low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 100
+        max-rate: 5000
+        acceleration: 50
+        travel: 100
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+probe: gpio.35
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/pen_laser_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/pen_laser_v1.yaml
@@ -6,10 +6,11 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 homing:
   feed-rate: 200
   seek-rate: 1000
-  debounce: 250
   pulloff: 3
 x:
   limit: gpio.2:low
@@ -40,8 +41,10 @@ z:
   travel: 100
 probe: gpio.35
 
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/pen_laser_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/pen_laser_v1.yaml
@@ -1,42 +1,43 @@
 ---
 name: PEN_LASER_V2
+board: bdring-pen-laser-v1
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 homing:
-        feed-rate: 200
-        seek-rate: 1000
-        debounce: 250
-        pulloff: 3
+  feed-rate: 200
+  seek-rate: 1000
+  debounce: 250
+  pulloff: 3
 x:
-        limit: gpio.2:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 80
-        max-rate: 5000
-        acceleration: 50
-        travel: 300
+  limit: gpio.2:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 80
+  max-rate: 5000
+  acceleration: 50
+  travel: 300
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 80
-        max-rate: 5000
-        acceleration: 50
-        travel: 300
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 80
+  max-rate: 5000
+  acceleration: 50
+  travel: 300
 z:
-        limit: gpio.15:low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 100
-        max-rate: 5000
-        acceleration: 50
-        travel: 100
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15:low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 100
+  max-rate: 5000
+  acceleration: 50
+  travel: 100
 probe: gpio.35
 
 status-report-mask: 1

--- a/Grbl_Esp32/src/MachineYAML/pen_laser_v2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/pen_laser_v2.yaml
@@ -6,10 +6,11 @@ defaults:
     disable: gpio.13
     pulse: 3
     idle: never
+  gpio:
+    debounce: 250
 homing:
   feed-rate: 200
   seek-rate: 1000
-  debounce: 250
   pulloff: 3
 x:
   limit: gpio.15:low
@@ -40,8 +41,10 @@ z:
   travel: 100
 probe: gpio.35
 
-status-report-mask: 1
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
-laser-mode: off
+report:
+  status-mask: 1
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/pen_laser_v2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/pen_laser_v2.yaml
@@ -1,0 +1,46 @@
+---
+name: PEN_LASER_V2
+homing:
+        feed-rate: 200
+        seek-rate: 1000
+        debounce: 250
+        pulloff: 3
+x:
+        limit: gpio.15:low
+        stepstick:
+                step: gpio.12
+                direction: gpio.26
+        spmm: 80
+        max-rate: 5000
+        acceleration: 50
+        travel: 300
+y:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.14
+                direction: gpio.25
+        spmm: 80
+        max-rate: 5000
+        acceleration: 50
+        travel: 300
+z:
+        limit: gpio.15:low
+        stepstick:
+                step: gpio.27
+                direction: gpio.33
+        spmm: 100
+        max-rate: 5000
+        acceleration: 50
+        travel: 100
+
+steppers:
+        disable: gpio.13
+        pulse: 3
+        idle: never
+probe: gpio.35
+
+status-report-mask: 1
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0
+laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/pen_laser_v2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/pen_laser_v2.yaml
@@ -1,42 +1,43 @@
 ---
 name: PEN_LASER_V2
+board: bdring-pen-laser-v2
+defaults:
+  steppers:
+    disable: gpio.13
+    pulse: 3
+    idle: never
 homing:
-        feed-rate: 200
-        seek-rate: 1000
-        debounce: 250
-        pulloff: 3
+  feed-rate: 200
+  seek-rate: 1000
+  debounce: 250
+  pulloff: 3
 x:
-        limit: gpio.15:low
-        stepstick:
-                step: gpio.12
-                direction: gpio.26
-        spmm: 80
-        max-rate: 5000
-        acceleration: 50
-        travel: 300
+  limit: gpio.15:low
+  stepstick:
+    step: gpio.12
+    direction: gpio.26
+  spmm: 80
+  max-rate: 5000
+  acceleration: 50
+  travel: 300
 y:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.14
-                direction: gpio.25
-        spmm: 80
-        max-rate: 5000
-        acceleration: 50
-        travel: 300
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.14
+    direction: gpio.25
+  spmm: 80
+  max-rate: 5000
+  acceleration: 50
+  travel: 300
 z:
-        limit: gpio.15:low
-        stepstick:
-                step: gpio.27
-                direction: gpio.33
-        spmm: 100
-        max-rate: 5000
-        acceleration: 50
-        travel: 100
-
-steppers:
-        disable: gpio.13
-        pulse: 3
-        idle: never
+  limit: gpio.15:low
+  stepstick:
+    step: gpio.27
+    direction: gpio.33
+  spmm: 100
+  max-rate: 5000
+  acceleration: 50
+  travel: 100
 probe: gpio.35
 
 status-report-mask: 1

--- a/Grbl_Esp32/src/MachineYAML/polar_coaster.yaml
+++ b/Grbl_Esp32/src/MachineYAML/polar_coaster.yaml
@@ -6,17 +6,17 @@ defaults:
     disable: gpio.17
     pulse: 3
     idle: never
+  gpio:
+    debounce: 100
 custom:
   filename: Custom/polar_coaster.cpp
   radius-axis: 0
   polar-axis: 1
   segment-length: 0.5
   forward-kinematics: on
-m30: on
 homing:
   feed-rate: 200
   seek-rate: 1000
-  debounce: 250
   pulloff: 3
 x:
   limit: gpio.4:low
@@ -43,14 +43,15 @@ z:
   acceleration: 50
   travel: 100
 
-debounce: on
-    period: 100
 macro:
-  button0: gpio.13:low
-  button1: gpio.12:low
-  button2: gpio.14:low
+  - gpio.13:low
+  - gpio.12:low
+  - gpio.14:low
 
-status-report-mask: 2
-junction_deviation: 0.01
-arc-tolerance: 0.002
-report-inches: 0
+report:
+  status-mask: 2
+  inches: off
+gcode:
+  junction-deviation: 0.01
+  arc-tolerance: 0.002
+  laser-mode: off

--- a/Grbl_Esp32/src/MachineYAML/polar_coaster.yaml
+++ b/Grbl_Esp32/src/MachineYAML/polar_coaster.yaml
@@ -1,0 +1,55 @@
+---
+name: POLAR_COASTER
+custom:
+        filename: Custom/polar_coaster.cpp
+        radius-axis: 0
+        polar-axis: 1
+        segment-length: 0.5
+        forward-kinematics: on
+m30: on
+homing:
+        feed-rate: 200
+        seek-rate: 1000
+        debounce: 250
+        pulloff: 3
+x:
+        limit: gpio.4:low
+        stepstick:
+                step: gpio.15
+                direction: gpio.25
+        spmm: 200
+        max-rate: 5000
+        acceleration: 200
+        travel: 50
+y:
+        stepstick:
+                step: gpio.2
+                direction: gpio.26
+        spmm: 71.111
+        max-rate: 15000
+        acceleration: 200
+        travel: 300
+z:
+        servo:
+                pin: gpio.16
+        spmm: 100
+        max-rate: 3000
+        acceleration: 50
+        travel: 100
+
+debounce: on
+          period: 100
+
+steppers:
+        disable: gpio.17
+        pulse: 3
+        idle: never
+macro:
+        button0: gpio.13:low
+        button1: gpio.12:low
+        button2: gpio.14:low
+
+status-report-mask: 2
+junction_deviation: 0.01
+arc-tolerance: 0.002
+report-inches: 0

--- a/Grbl_Esp32/src/MachineYAML/polar_coaster.yaml
+++ b/Grbl_Esp32/src/MachineYAML/polar_coaster.yaml
@@ -1,53 +1,54 @@
 ---
 name: POLAR_COASTER
+board: bdring-polar-coaster
+defaults:
+  steppers:
+    disable: gpio.17
+    pulse: 3
+    idle: never
 custom:
-        filename: Custom/polar_coaster.cpp
-        radius-axis: 0
-        polar-axis: 1
-        segment-length: 0.5
-        forward-kinematics: on
+  filename: Custom/polar_coaster.cpp
+  radius-axis: 0
+  polar-axis: 1
+  segment-length: 0.5
+  forward-kinematics: on
 m30: on
 homing:
-        feed-rate: 200
-        seek-rate: 1000
-        debounce: 250
-        pulloff: 3
+  feed-rate: 200
+  seek-rate: 1000
+  debounce: 250
+  pulloff: 3
 x:
-        limit: gpio.4:low
-        stepstick:
-                step: gpio.15
-                direction: gpio.25
-        spmm: 200
-        max-rate: 5000
-        acceleration: 200
-        travel: 50
+  limit: gpio.4:low
+  stepstick:
+    step: gpio.15
+    direction: gpio.25
+  spmm: 200
+  max-rate: 5000
+  acceleration: 200
+  travel: 50
 y:
-        stepstick:
-                step: gpio.2
-                direction: gpio.26
-        spmm: 71.111
-        max-rate: 15000
-        acceleration: 200
-        travel: 300
+  stepstick:
+    step: gpio.2
+    direction: gpio.26
+  spmm: 71.111
+  max-rate: 15000
+  acceleration: 200
+  travel: 300
 z:
-        servo:
-                pin: gpio.16
-        spmm: 100
-        max-rate: 3000
-        acceleration: 50
-        travel: 100
+  servo:
+    pin: gpio.16
+  spmm: 100
+  max-rate: 3000
+  acceleration: 50
+  travel: 100
 
 debounce: on
-          period: 100
-
-steppers:
-        disable: gpio.17
-        pulse: 3
-        idle: never
+    period: 100
 macro:
-        button0: gpio.13:low
-        button1: gpio.12:low
-        button2: gpio.14:low
+  button0: gpio.13:low
+  button1: gpio.12:low
+  button2: gpio.14:low
 
 status-report-mask: 2
 junction_deviation: 0.01

--- a/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyyz.yaml
@@ -1,0 +1,39 @@
+---
+name: SPI_DAISY_4X_xyyz
+homing:
+        squared: y
+x:
+        limit: gpio.36:low
+        tmc2130:
+                step: gpio.12
+                direction: gpio.14
+                cs: gpio.17
+		rsense: 0.11
+y:
+	limit: gpio.39:low
+	tmc2130:
+                step: gpio.27
+                direction: gpio.26
+                cs: gpio.17
+		rsense: 0.11
+y2:
+	tmc2130:
+                step: gpio.15
+                direction: gpio.2
+                cs: gpio.17
+		rsense: 0.11
+z:
+	limit: gpio.34:low
+	tmc2130:
+                step: gpio.33
+                direction: gpio.32
+                cs: gpio.17
+		rsense: 0.11
+mist: gpio.21
+probe: gpio.22
+spindle:
+        pwm:
+                output: gpio.25
+                enable: gpio.4
+                direction: gpio.16
+                rpm-max: 1

--- a/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyyz.yaml
@@ -1,39 +1,40 @@
 ---
 name: SPI_DAISY_4X_xyyz
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: stealthchop
+    homing: stealthchop
 homing:
-        squared: y
+  squared: y
 x:
-        limit: gpio.36:low
-        tmc2130:
-                step: gpio.12
-                direction: gpio.14
-                cs: gpio.17
-		rsense: 0.11
+  limit: gpio.36:low
+  tmc2130:
+    step: gpio.12
+    direction: gpio.14
+    cs: gpio.17
 y:
-	limit: gpio.39:low
-	tmc2130:
-                step: gpio.27
-                direction: gpio.26
-                cs: gpio.17
-		rsense: 0.11
+  limit: gpio.39:low
+  tmc2130:
+    step: gpio.27
+    direction: gpio.26
+    cs: gpio.17
 y2:
-	tmc2130:
-                step: gpio.15
-                direction: gpio.2
-                cs: gpio.17
-		rsense: 0.11
+  tmc2130:
+    step: gpio.15
+    direction: gpio.2
+    cs: gpio.17
 z:
-	limit: gpio.34:low
-	tmc2130:
-                step: gpio.33
-                direction: gpio.32
-                cs: gpio.17
-		rsense: 0.11
+  limit: gpio.34:low
+  tmc2130:
+    step: gpio.33
+    direction: gpio.32
+    cs: gpio.17
 mist: gpio.21
 probe: gpio.22
 spindle:
-        pwm:
-                output: gpio.25
-                enable: gpio.4
-                direction: gpio.16
-                rpm-max: 1
+  pwm:
+    output: gpio.25
+    enable: gpio.4
+    direction: gpio.16
+    rpm-max: 1

--- a/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyz.yaml
@@ -1,38 +1,34 @@
 ---
 name: SPI_DAISY_4X_XYZ
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: coolstep
+    homing: coolstep
 homing:
-        squared: y
+  squared: y
 x:
-        limit: gpio.36:low
-        tmc2130:
-                step: gpio.12
-                direction: gpio.14
-                cs: gpio.17
-		rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.36:low
+  tmc2130:
+    step: gpio.12
+    direction: gpio.14
+    cs: gpio.17
 y:
-	limit: gpio.39:low
-	tmc2130:
-                step: gpio.27
-                direction: gpio.26
-                cs: gpio.17
-		rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.39:low
+  tmc2130:
+    step: gpio.27
+    direction: gpio.26
+    cs: gpio.17
 z:
-	limit: gpio.34:low
-	tmc2130:
-                step: gpio.15
-                direction: gpio.2
-                cs: gpio.17
-		rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.34:low
+  tmc2130:
+    step: gpio.15
+    direction: gpio.2
+    cs: gpio.17
 mist: gpio.21
 probe: gpio.22
 spindle:
-        pwm:
-                output: gpio.25
-                enable: gpio.4
-                rpm-max: 1
+  pwm:
+    output: gpio.25
+    enable: gpio.4
+    rpm-max: 1

--- a/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyz.yaml
+++ b/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyz.yaml
@@ -1,0 +1,38 @@
+---
+name: SPI_DAISY_4X_XYZ
+homing:
+        squared: y
+x:
+        limit: gpio.36:low
+        tmc2130:
+                step: gpio.12
+                direction: gpio.14
+                cs: gpio.17
+		rsense: 0.11
+                run: coolstep
+                homing: coolstep
+y:
+	limit: gpio.39:low
+	tmc2130:
+                step: gpio.27
+                direction: gpio.26
+                cs: gpio.17
+		rsense: 0.11
+                run: coolstep
+                homing: coolstep
+z:
+	limit: gpio.34:low
+	tmc2130:
+                step: gpio.15
+                direction: gpio.2
+                cs: gpio.17
+		rsense: 0.11
+                run: coolstep
+                homing: coolstep
+mist: gpio.21
+probe: gpio.22
+spindle:
+        pwm:
+                output: gpio.25
+                enable: gpio.4
+                rpm-max: 1

--- a/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyza.yaml
+++ b/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyza.yaml
@@ -1,39 +1,39 @@
 ---
 name: SPI_DAISY_4X XYZA
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: stealthchop
+    homing: stealthchop
 homing:
-        squared: y
+  squared: y
 x:
-        limit: gpio.36:low
-        tmc2130:
-                step: gpio.12
-                direction: gpio.14
-                cs: gpio.17
-		rsense: 0.11
-                run: stealthchop
+  limit: gpio.36:low
+  tmc2130:
+    step: gpio.12
+    direction: gpio.14
+    cs: gpio.17
 y:
-	limit: gpio.39:low
-	tmc2130:
-                step: gpio.27
-                direction: gpio.26
-                cs: gpio.17
-		rsense: 0.11
+  limit: gpio.39:low
+  tmc2130:
+    step: gpio.27
+    direction: gpio.26
+    cs: gpio.17
 z:
-	limit: gpio.34:low
-	tmc2130:
-                step: gpio.15
-                direction: gpio.2
-                cs: gpio.17
-		rsense: 0.11
+  limit: gpio.34:low
+  tmc2130:
+    step: gpio.15
+    direction: gpio.2
+    cs: gpio.17
 a:
-	limit: gpio.35:low
-	tmc2130:
-                step: gpio.33
-                direction: gpio.32
-                cs: gpio.17
-		rsense: 0.11
+  limit: gpio.35:low
+  tmc2130:
+    step: gpio.33
+    direction: gpio.32
+    cs: gpio.17
 mist: gpio.21
 probe: gpio.22
 spindle:
-        relay:
-                output: gpio.25
-                enable: gpio.4
+  relay:
+    output: gpio.25
+    enable: gpio.4

--- a/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyza.yaml
+++ b/Grbl_Esp32/src/MachineYAML/spi_daisy_4axis_xyza.yaml
@@ -1,0 +1,39 @@
+---
+name: SPI_DAISY_4X XYZA
+homing:
+        squared: y
+x:
+        limit: gpio.36:low
+        tmc2130:
+                step: gpio.12
+                direction: gpio.14
+                cs: gpio.17
+		rsense: 0.11
+                run: stealthchop
+y:
+	limit: gpio.39:low
+	tmc2130:
+                step: gpio.27
+                direction: gpio.26
+                cs: gpio.17
+		rsense: 0.11
+z:
+	limit: gpio.34:low
+	tmc2130:
+                step: gpio.15
+                direction: gpio.2
+                cs: gpio.17
+		rsense: 0.11
+a:
+	limit: gpio.35:low
+	tmc2130:
+                step: gpio.33
+                direction: gpio.32
+                cs: gpio.17
+		rsense: 0.11
+mist: gpio.21
+probe: gpio.22
+spindle:
+        relay:
+                output: gpio.25
+                enable: gpio.4

--- a/Grbl_Esp32/src/MachineYAML/tapster3.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tapster3.yaml
@@ -1,66 +1,67 @@
 ---
 name: Tapster 3 Delta (Dynamixel)
+defaults:
+  steppers:
+    pulse: 3
+    idle: 200
 custom:
-        forward-kinematics: on
-        filename: Custom/parallel_delta.cpp
-        machine-init: on
-        radius-fixed: 70
-        radius-eff: 133.5
-        length-fixed: 179.437
-        length-eff: 86.6025
-        segment-length: 0.5
-        max-negative-angle: -45
-        arm-internal-angle: 2.866
-        servo-timer-interval: 50
+  forward-kinematics: on
+  filename: Custom/parallel_delta.cpp
+  machine-init: on
+  radius-fixed: 70
+  radius-eff: 133.5
+  length-fixed: 179.437
+  length-eff: 86.6025
+  segment-length: 0.5
+  max-negative-angle: -45
+  arm-internal-angle: 2.866
+  servo-timer-interval: 50
 x:
-        dynamixel:
-                TxD: gpio.4
-                RxD: gpio.13
-                RTS: gpio.17
-                protocol: 1
-                count-min: 1024
-                count-max: 3072
-        spmm: 800
-        max-rate: 200
-        acceleration: 200
-        max-travel: 3.14159265
-        mpos: 1.57079632675
+  dynamixel:
+    TxD: gpio.4
+    RxD: gpio.13
+    RTS: gpio.17
+    protocol: 1
+    count-min: 1024
+    count-max: 3072
+  spmm: 800
+  max-rate: 200
+  acceleration: 200
+  max-travel: 3.14159265
+  mpos: 1.57079632675
 y:
-        dynamixel:
-                protocol: 2
-                count-min: 1024
-                count-max: 3072
-        spmm: 800
-        max-rate: 200
-        acceleration: 200
-        max-travel: 3.14159265
-        mpos: 1.57079632675
+  dynamixel:
+    protocol: 2
+    count-min: 1024
+    count-max: 3072
+  spmm: 800
+  max-rate: 200
+  acceleration: 200
+  max-travel: 3.14159265
+  mpos: 1.57079632675
 z:
-        dynamixel:
-                protocol: 3
-                count-min: 1024
-                count-max: 3072
-        spmm: 800
-        max-rate: 200
-        acceleration: 200
-        max-travel: 3.14159265
-        mpos: 1.57079632675
-steppers:
-        pulse: 3
-        idle: 200
+  dynamixel:
+    protocol: 3
+    count-min: 1024
+    count-max: 3072
+  spmm: 800
+  max-rate: 200
+  acceleration: 200
+  max-travel: 3.14159265
+  mpos: 1.57079632675
 user-digital0:
-        pin: gpio.25
+  pin: gpio.25
 user-digital1:
-        pin: gpio.26
+  pin: gpio.26
 user-digital2:
-        pin: gpio.27
+  pin: gpio.27
 user-analog0:
-        pin: gpio.2
-        frequency: 50
+  pin: gpio.2
+  frequency: 50
 user-analog1:
-        pin: gpio.15
-        frequency: 50
+  pin: gpio.15
+  frequency: 50
 user-analog2:
-        pin: gpio.16
-        frequency: 50
+  pin: gpio.16
+  frequency: 50
 status-report-mask: 1

--- a/Grbl_Esp32/src/MachineYAML/tapster3.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tapster3.yaml
@@ -49,19 +49,18 @@ z:
   acceleration: 200
   max-travel: 3.14159265
   mpos: 1.57079632675
-user-digital0:
-  pin: gpio.25
-user-digital1:
-  pin: gpio.26
-user-digital2:
-  pin: gpio.27
-user-analog0:
-  pin: gpio.2
-  frequency: 50
-user-analog1:
-  pin: gpio.15
-  frequency: 50
-user-analog2:
-  pin: gpio.16
-  frequency: 50
+user-digital:
+  - pin: gpio.25
+  - pin: gpio.26
+  - pin: gpio.27
+user-analog:
+  - analog-pin:
+      frequency: 50
+      pin: gpio.2
+  - analog-pin:
+      frequency: 50
+      pin: gpio.15
+  - analog-pin:
+      frequency: 50
+      pin: gpio.16
 status-report-mask: 1

--- a/Grbl_Esp32/src/MachineYAML/tapster3.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tapster3.yaml
@@ -1,0 +1,66 @@
+---
+name: Tapster 3 Delta (Dynamixel)
+custom:
+        forward-kinematics: on
+        filename: Custom/parallel_delta.cpp
+        machine-init: on
+        radius-fixed: 70
+        radius-eff: 133.5
+        length-fixed: 179.437
+        length-eff: 86.6025
+        segment-length: 0.5
+        max-negative-angle: -45
+        arm-internal-angle: 2.866
+        servo-timer-interval: 50
+x:
+        dynamixel:
+                TxD: gpio.4
+                RxD: gpio.13
+                RTS: gpio.17
+                protocol: 1
+                count-min: 1024
+                count-max: 3072
+        spmm: 800
+        max-rate: 200
+        acceleration: 200
+        max-travel: 3.14159265
+        mpos: 1.57079632675
+y:
+        dynamixel:
+                protocol: 2
+                count-min: 1024
+                count-max: 3072
+        spmm: 800
+        max-rate: 200
+        acceleration: 200
+        max-travel: 3.14159265
+        mpos: 1.57079632675
+z:
+        dynamixel:
+                protocol: 3
+                count-min: 1024
+                count-max: 3072
+        spmm: 800
+        max-rate: 200
+        acceleration: 200
+        max-travel: 3.14159265
+        mpos: 1.57079632675
+steppers:
+        pulse: 3
+        idle: 200
+user-digital0:
+        pin: gpio.25
+user-digital1:
+        pin: gpio.26
+user-digital2:
+        pin: gpio.27
+user-analog0:
+        pin: gpio.2
+        frequency: 50
+user-analog1:
+        pin: gpio.15
+        frequency: 50
+user-analog2:
+        pin: gpio.16
+        frequency: 50
+status-report-mask: 1

--- a/Grbl_Esp32/src/MachineYAML/test_drive.yaml
+++ b/Grbl_Esp32/src/MachineYAML/test_drive.yaml
@@ -1,0 +1,5 @@
+---
+name: Test Drive - Demo Only No I/O!
+homing:
+        cycle0:
+        cycle1:

--- a/Grbl_Esp32/src/MachineYAML/test_drive.yaml
+++ b/Grbl_Esp32/src/MachineYAML/test_drive.yaml
@@ -1,5 +1,4 @@
 ---
 name: Test Drive - Demo Only No I/O!
 homing:
-        cycle0:
-        cycle1:
+  cycles:

--- a/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v1.yaml
@@ -1,0 +1,28 @@
+---
+name: ESP32_TMC2130_PEN V1
+x:
+        limit: gpio.2:low
+        tmc2130:
+                step: gpio.12
+                direction: gpio.26
+                cs: gpio.17
+                rsense: 0.11
+                run: coolstep
+                homing: coolstep
+y:
+        limit: gpio.4:low
+        tmc2130:
+                step: gpio.14
+                direction: gpio.25
+                cs: gpio.16
+                rsense: 0.11
+                run: coolstep
+                homing: coolstep
+z:
+        servo:
+                pin: gpio.27
+        spmm: 100
+        travel: 300
+
+steppers:
+        disable: gpio.13

--- a/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v1.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v1.yaml
@@ -1,28 +1,26 @@
 ---
 name: ESP32_TMC2130_PEN V1
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: coolstep
+    homing: coolstep
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.2:low
-        tmc2130:
-                step: gpio.12
-                direction: gpio.26
-                cs: gpio.17
-                rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.2:low
+  tmc2130:
+    step: gpio.12
+    direction: gpio.26
+    cs: gpio.17
 y:
-        limit: gpio.4:low
-        tmc2130:
-                step: gpio.14
-                direction: gpio.25
-                cs: gpio.16
-                rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.4:low
+  tmc2130:
+    step: gpio.14
+    direction: gpio.25
+    cs: gpio.16
 z:
-        servo:
-                pin: gpio.27
-        spmm: 100
-        travel: 300
-
-steppers:
-        disable: gpio.13
+  servo:
+    pin: gpio.27
+  spmm: 100
+  travel: 300

--- a/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v2.yaml
@@ -1,27 +1,26 @@
 ---
 name: ESP32_TMC2130_PEN V2
+defaults:
+  tmc2130:
+    rsense: 0.11
+    run: coolstep
+    homing: coolstep
+  steppers:
+    disable: gpio.13
 x:
-        limit: gpio.32:low
-        tmc2130:
-                step: gpio.12
-                direction: gpio.26
-                cs: gpio.17
-                rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.32:low
+  tmc2130:
+    step: gpio.12
+    direction: gpio.26
+    cs: gpio.17
 y:
-        limit: gpio.4:low
-        tmc2130:
-                step: gpio.14
-                direction: gpio.25
-                cs: gpio.16
-                rsense: 0.11
-                run: coolstep
-                homing: coolstep
+  limit: gpio.4:low
+  tmc2130:
+    step: gpio.14
+    direction: gpio.25
+    cs: gpio.16
 z:
-        servo:
-                pin: gpio.27
-        spmm: 100
-        travel: 300
-steppers:
-        disable: gpio.13
+  servo:
+    pin: gpio.27
+  spmm: 100
+  travel: 300

--- a/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v2.yaml
+++ b/Grbl_Esp32/src/MachineYAML/tmc2130_pen_v2.yaml
@@ -1,0 +1,27 @@
+---
+name: ESP32_TMC2130_PEN V2
+x:
+        limit: gpio.32:low
+        tmc2130:
+                step: gpio.12
+                direction: gpio.26
+                cs: gpio.17
+                rsense: 0.11
+                run: coolstep
+                homing: coolstep
+y:
+        limit: gpio.4:low
+        tmc2130:
+                step: gpio.14
+                direction: gpio.25
+                cs: gpio.16
+                rsense: 0.11
+                run: coolstep
+                homing: coolstep
+z:
+        servo:
+                pin: gpio.27
+        spmm: 100
+        travel: 300
+steppers:
+        disable: gpio.13


### PR DESCRIPTION
YAML machine descriptions, grist for discussion.

I suspect that these files could be parsed at startup to configure machines, without using the Settings at all.  Instead of storing settings in NVS, you just have a YAML file in SPIFFS.  The startup code reads it - on every startup - to configure the machine.