### PR TITLE
Settings filtering via regular expressions

### DIFF
--- a/Grbl_Esp32/src/ProcessSettings.cpp
+++ b/Grbl_Esp32/src/ProcessSettings.cpp
@@ -1,5 +1,6 @@
 #include "Grbl.h"
 #include <map>
+#include "Regex.h"
 
 // WG Readable and writable as guest
 // WU Readable and writable as user and admin
@@ -565,19 +566,13 @@ Error do_command_or_setting(const char* key, char* value, WebUI::AuthenticationL
     Error retval = Error::InvalidStatement;
     if (!value) {
         auto lcKey = String(key);
-        // We allow the key string to begin with *, which we remove.
-        // This lets us look at X axis settings with $*x.
-        // $x by itself is the disable alarm lock command
-        if (lcKey.startsWith("*")) {
-            lcKey.remove(0, 1);
-        }
         lcKey.toLowerCase();
         bool found = false;
         for (Setting* s = Setting::List; s; s = s->next()) {
             auto lcTest = String(s->getName());
             lcTest.toLowerCase();
 
-            if (lcTest.indexOf(lcKey) >= 0) {
+            if (regexMatch(lcKey.c_str(), lcTest.c_str())) {
                 const char* displayValue = auth_failed(s, value, auth_level) ? "<Authentication required>" : s->getStringValue();
                 show_setting(s->getName(), displayValue, NULL, out);
                 found = true;

--- a/Grbl_Esp32/src/Regex.cpp
+++ b/Grbl_Esp32/src/Regex.cpp
@@ -40,6 +40,7 @@ static bool matchHere(const char* regexp, const char* text) {
 }
 
 // match - search for regular expression anywhere in text
+// Returns true if text contains the regular expression regexp
 bool regexMatch(const char* regexp, const char* text) {
     if (regexp[0] == '^') {
         return matchHere(++regexp, text);

--- a/Grbl_Esp32/src/Regex.cpp
+++ b/Grbl_Esp32/src/Regex.cpp
@@ -2,23 +2,29 @@
 // https://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html
 
 //    c    matches any literal character c
-//    .    matches any single character
 //    ^    matches the beginning of the input string
 //    $    matches the end of the input string
-//    *    matches zero or more occurrences of the previous character
+//    *    matches zero or more occurrences of any character
 
-// The code therein has been reformatted into the style used in
-// this project, with ints used as flags replaced by bools
+// The code therein has been reformatted into the style used in this
+// project while replacing ints used as flags by bools.  The regex
+// syntax was changed by omitting '.' and making '*' equivalent to
+// ".*".  This regular expression matcher is for matching setting
+// names, where arbitrary repetion of literal characters is
+// unlikely.  Literal character repetition is most useful for
+// skipping whitespace, which does not occur in setting names.  The
+// "bare * wildcard" is similar to filename wildcarding in many shells
+// and CLIs.
 
 static bool matchHere(const char* regexp, const char* text);
 
-// matchStar - search for c*regexp at beginning of text
-static bool matchStar(int c, const char* regexp, const char* text) {
+// matchStar - search for *regexp at beginning of text
+static bool matchStar(const char* regexp, const char* text) {
     do {
         if (matchHere(regexp, text)) {
             return true;
         }
-    } while (*text != '\0' && (*text++ == c || c == '.'));
+    } while (*text++ != '\0');
     return false;
 }
 
@@ -27,13 +33,13 @@ static bool matchHere(const char* regexp, const char* text) {
     if (regexp[0] == '\0') {
         return true;
     }
-    if (regexp[1] == '*') {
-        return matchStar(regexp[0], regexp + 2, text);
+    if (regexp[0] == '*') {
+        return matchStar(regexp + 1, text);
     }
     if (regexp[0] == '$' && regexp[1] == '\0') {
         return *text == '\0';
     }
-    if (*text != '\0' && (regexp[0] == '.' || regexp[0] == *text)) {
+    if (*text != '\0' && (regexp[0] == *text)) {
         return matchHere(++regexp, ++text);
     }
     return false;

--- a/Grbl_Esp32/src/Regex.cpp
+++ b/Grbl_Esp32/src/Regex.cpp
@@ -1,0 +1,53 @@
+// Simple regular expression matcher from Rob Pike per
+// https://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html
+
+//    c    matches any literal character c
+//    .    matches any single character
+//    ^    matches the beginning of the input string
+//    $    matches the end of the input string
+//    *    matches zero or more occurrences of the previous character
+
+// The code therein has been reformatted into the style used in
+// this project, with ints used as flags replaced by bools
+
+static bool matchHere(const char* regexp, const char* text);
+
+// matchStar - search for c*regexp at beginning of text
+static bool matchStar(int c, const char* regexp, const char* text) {
+    do {
+        if (matchHere(regexp, text)) {
+            return true;
+        }
+    } while (*text != '\0' && (*text++ == c || c == '.'));
+    return false;
+}
+
+// matchHere - search for regex at beginning of text
+static bool matchHere(const char* regexp, const char* text) {
+    if (regexp[0] == '\0') {
+        return true;
+    }
+    if (regexp[1] == '*') {
+        return matchStar(regexp[0], regexp + 2, text);
+    }
+    if (regexp[0] == '$' && regexp[1] == '\0') {
+        return *text == '\0';
+    }
+    if (*text != '\0' && (regexp[0] == '.' || regexp[0] == *text)) {
+        return matchHere(++regexp, ++text);
+    }
+    return false;
+}
+
+// match - search for regular expression anywhere in text
+bool regexMatch(const char* regexp, const char* text) {
+    if (regexp[0] == '^') {
+        return matchHere(++regexp, text);
+    }
+    do {
+        if (matchHere(regexp, text)) {
+            return true;
+        }
+    } while (*text++ != '\0');
+    return false;
+}

--- a/Grbl_Esp32/src/Regex.h
+++ b/Grbl_Esp32/src/Regex.h
@@ -1,11 +1,5 @@
-// Simple regular expression matcher from Rob Pike per
-// https://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html
-
-//    c    matches any literal character c
-//    .    matches any single character
-//    ^    matches the beginning of the input string
-//    $    matches the end of the input string
-//    *    matches zero or more occurrences of the previous character
+// Simple regular expression matcher.
+// See Regex.cpp for attribution, description and discussion
 
 // Returns true if text contains the regular expression regexp
 bool regexMatch(const char* regexp, const char* text);

--- a/Grbl_Esp32/src/Regex.h
+++ b/Grbl_Esp32/src/Regex.h
@@ -7,4 +7,5 @@
 //    $    matches the end of the input string
 //    *    matches zero or more occurrences of the previous character
 
+// Returns true if text contains the regular expression regexp
 bool regexMatch(const char* regexp, const char* text);

--- a/Grbl_Esp32/src/Regex.h
+++ b/Grbl_Esp32/src/Regex.h
@@ -1,0 +1,10 @@
+// Simple regular expression matcher from Rob Pike per
+// https://www.cs.princeton.edu/courses/archive/spr09/cos333/beautiful.html
+
+//    c    matches any literal character c
+//    .    matches any single character
+//    ^    matches the beginning of the input string
+//    $    matches the end of the input string
+//    *    matches zero or more occurrences of the previous character
+
+bool regexMatch(const char* regexp, const char* text);


### PR DESCRIPTION
Implements only the most basic - and the most
useful - special characters - ^$.*

If the search string does not contain a special
character, it is interpreted as before.  Otherwise
the match is either more strict if anchored by
^ or $, or less strict if it contains a * wildcard .

Some examples:

`$y` - settings that contain y (as before)
`$^y` - settings that start with y
`$y$` - settings that end with y
`$^y*pin` - settings that start with y and contain pin
`$^y*rd$` - settings that start with y and end with rd

Note that `$x` is a classic grbl command as always.  If you want to see settings that contain x, you can write `$*x`.  For settings that start with x, use `$^x` .  In general, this works with any existing Grbl command - by inserting a * , you can force it to be interpreted as a setting instead of a command.
