### PR TITLE
Pwm integer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __vm/
 *.vcxproj.filters
 *.suo
 Grbl_Esp32.ino.cpp
+/packages

--- a/Grbl_Esp32/src/Duty.h
+++ b/Grbl_Esp32/src/Duty.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+class Duty {
+    int32_t value_;
+
+public:
+    inline Duty() : value_(0) {}
+
+    Duty(const Duty& o) = default;
+    Duty& operator=(const Duty& o) = default;
+
+    inline Duty(int percentage) {
+        if (percentage <= 0) {
+            value_ = 0;
+        } else if (percentage >= 100) {
+            value_ = 1000000000;
+        } else {
+            value_ = int32_t(percentage * 10000000);
+        }
+    }
+
+    inline Duty(float percentage) {
+        if (percentage <= 0.0f) {
+            value_ = 0;
+        } else if (percentage >= 100.0f) {
+            value_ = 1000000000;
+        } else {
+            value_ = int32_t(percentage * 10000000);
+        }
+    }
+
+    inline uint32_t get_duty_cycle(uint8_t resolutionBits) const {
+        uint64_t tmp = value_ * uint64_t(1 << resolutionBits);
+        tmp /= 10000000;
+        return uint32_t(tmp);
+    }
+
+    inline float get_percentage() const { return float(value_) / float(10000000); }
+};

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -506,7 +506,9 @@ void mc_reset() {
 
         // turn off all User I/O immediately
         sys_io_control(0xFF, LOW, false);
-        sys_pwm_control(0xFF, 0, false);
+
+        // Explicitly use the INT overload of Duty; we cannot use float in this context!
+        sys_pwm_control(0xFF, int(0), false); 
 #ifdef ENABLE_SD_CARD
         // do we need to stop a running SD job?
         if (get_sd_state(false) == SDCARD_BUSY_PRINTING) {

--- a/Grbl_Esp32/src/System.cpp
+++ b/Grbl_Esp32/src/System.cpp
@@ -285,7 +285,7 @@ bool sys_io_control(uint8_t io_num_mask, bool turnOn, bool synchronized) {
 
 // io_num is the virtual pin# and has nothing to do with the actual esp32 GPIO_NUM_xx
 // It uses a mask so all can be turned of in ms_reset
-bool sys_pwm_control(uint8_t io_num_mask, float duty, bool synchronized) {
+bool sys_pwm_control(uint8_t io_num_mask, Duty duty, bool synchronized) {
     bool cmd_ok = true;
     if (synchronized)
         protocol_buffer_synchronize();

--- a/Grbl_Esp32/src/System.h
+++ b/Grbl_Esp32/src/System.h
@@ -22,6 +22,7 @@
 
 // Execution states and alarm
 #include "Exec.h"
+#include "Duty.h"
 
 // System states. The state variable primarily tracks the individual functions
 // of Grbl to manage each without overlapping. It is also used as a messaging flag for
@@ -171,7 +172,7 @@ void controlCheckTask(void* pvParameters);
 void system_exec_control_pin(ControlPins pins);
 
 bool sys_io_control(uint8_t io_num_mask, bool turnOn, bool synchronized);
-bool sys_pwm_control(uint8_t io_num_mask, float duty, bool synchronized);
+bool sys_pwm_control(uint8_t io_num_mask, Duty duty, bool synchronized);
 
 int8_t  sys_get_next_PWM_chan_num();
 uint8_t sys_calc_pwm_precision(uint32_t freq);

--- a/Grbl_Esp32/src/UserOutput.cpp
+++ b/Grbl_Esp32/src/UserOutput.cpp
@@ -89,9 +89,7 @@ namespace UserOutput {
     }
 
     // returns true if able to set value
-    bool AnalogOutput::set_level(float percent) {
-        float duty;
-
+    bool AnalogOutput::set_level(Duty percent) {
         // look for errors, but ignore if turning off to prevent mask turn off from generating errors
         if (_pin == UNDEFINED_PIN) {
             return false;
@@ -102,13 +100,7 @@ namespace UserOutput {
             return false;
         }
 
-        if (_current_value == percent)
-            return true;
-
-        _current_value = percent;
-
-        duty = (percent / 100.0) * (1 << _resolution_bits);
-
+        auto duty = percent.get_duty_cycle(_resolution_bits);
         ledcWrite(_pwm_channel, duty);
 
         return true;

--- a/Grbl_Esp32/src/UserOutput.h
+++ b/Grbl_Esp32/src/UserOutput.h
@@ -20,6 +20,7 @@
 */
 
 #include "Grbl.h"
+#include "Duty.h"
 
 namespace UserOutput {
     class DigitalOutput {
@@ -41,7 +42,8 @@ namespace UserOutput {
     public:
         AnalogOutput();
         AnalogOutput(uint8_t number, uint8_t pin, float pwm_frequency);
-        bool set_level(float percent);
+        
+        bool set_level(Duty percent);
 
     protected:
         void init();


### PR DESCRIPTION
2 changes.

1. Changes spindle to volatile, because it's used by multiple CPU's. This is good enough for now, because the implementations basically just set pins off. In the long term, we need a better solution.

2. Changed PWM analog user output to integers. The reason is because of a crash in Devt when limits are hit:

0x400dee4d> 0x400dee4d is in UserOutput::AnalogOutput::set_level(float) (Grbl_Esp32\src\UserOutput.cpp:92).
92          bool AnalogOutput::set_level(float percent) {
0x400dea4c> 0x400dea4c is in sys_pwm_control(unsigned char, float, bool) (Grbl_Esp32\src\System.cpp:295).
295                 if (!myAnalogOutputs[io_num]->set_level(duty))
0x400d53ac> 0x400d53ac is in mc_reset() (Grbl_Esp32\src\MotionControl.cpp:509).
509             sys_pwm_control(0xFF, 0, false);
0x40081f17> 0x40081f17 is in isr_limit_switches() (Grbl_Esp32\src\Limits.cpp:62).
62                  mc_reset();                                // Initiate system kill.

[...]

Apparently floating point is not allowed in ISR's. These changes should fix that.