### PR TITLE
fix race with sys_rt_exec_state by breaking out bools - v2

### DIFF
--- a/Grbl_Esp32/Custom/CoreXY.cpp
+++ b/Grbl_Esp32/Custom/CoreXY.cpp
@@ -147,9 +147,9 @@ bool user_defined_homing(uint8_t cycle_mask) {
                         }
                         st_prep_buffer();  // Check and prep segment buffer. NOTE: Should take no longer than 200us.
                         // Exit routines: No time to run protocol_execute_realtime() in this loop.
-                        if (sys_rt_exec_state.bit.safetyDoor || sys_rt_exec_state.bit.reset || cycle_stop) {
+                        if (sys_safetyDoor || sys_reset || sys_cycleStop) {
                             ExecState rt_exec_state;
-                            rt_exec_state.value = sys_rt_exec_state.value;
+                            rt_exec_state.value = sys_get_rt_exec_state().value;
                             // Homing failure condition: Reset issued during cycle.
                             if (rt_exec_state.bit.reset) {
                                 sys_rt_exec_alarm = ExecAlarm::HomingFailReset;
@@ -163,7 +163,7 @@ bool user_defined_homing(uint8_t cycle_mask) {
                                 sys_rt_exec_alarm = ExecAlarm::HomingFailPulloff;
                             }
                             // Homing failure condition: Limit switch not found during approach.
-                            if (approach && cycle_stop) {
+                            if (approach && rt_exec_state.bit.cycleStop) {
                                 sys_rt_exec_alarm = ExecAlarm::HomingFailApproach;
                             }
 
@@ -174,7 +174,7 @@ bool user_defined_homing(uint8_t cycle_mask) {
                                 return true;
                             } else {
                                 // Pull-off motion complete. Disable CYCLE_STOP from executing.
-                                cycle_stop = false;
+                                sys_cycleStop = false;
                                 break;
                             }
                         }

--- a/Grbl_Esp32/src/Exec.h
+++ b/Grbl_Esp32/src/Exec.h
@@ -10,7 +10,7 @@
 struct ExecStateBits {
     uint8_t statusReport : 1;
     uint8_t cycleStart : 1;
-    uint8_t cycleStop : 1;  // Unused, per cycle_stop variable
+    uint8_t cycleStop : 1; 
     uint8_t feedHold : 1;
     uint8_t reset : 1;
     uint8_t safetyDoor : 1;

--- a/Grbl_Esp32/src/GCode.cpp
+++ b/Grbl_Esp32/src/GCode.cpp
@@ -1563,7 +1563,7 @@ Error gc_execute_line(char* line, uint8_t client) {
         case ProgramFlow::Paused:
             protocol_buffer_synchronize();  // Sync and finish all remaining buffered motions before moving on.
             if (sys.state != State::CheckMode) {
-                sys_rt_exec_state.bit.feedHold = true;  // Use feed hold for program pause.
+                sys_feedHold = true;  // Use feed hold for program pause.
                 protocol_execute_realtime();            // Execute suspend.
             }
             break;

--- a/Grbl_Esp32/src/Grbl.cpp
+++ b/Grbl_Esp32/src/Grbl.cpp
@@ -86,10 +86,18 @@ static void reset_variables() {
     memset(sys_probe_position, 0, sizeof(sys_probe_position));  // Clear probe position.
 
     sys_probe_state                      = Probe::Off;
-    sys_rt_exec_state.value              = 0;
+
+    sys_statusReport                     = false;
+    sys_cycleStart                       = false;
+    sys_cycleStop                        = false;
+    sys_feedHold                         = false;
+    sys_reset                            = false;
+    sys_safetyDoor                       = false;
+    sys_motionCancel                     = false;
+    sys_sleep                            = false;
+
     sys_rt_exec_accessory_override.value = 0;
     sys_rt_exec_alarm                    = ExecAlarm::None;
-    cycle_stop                           = false;
     sys_rt_f_override                    = FeedOverride::Default;
     sys_rt_r_override                    = RapidOverride::Default;
     sys_rt_s_override                    = SpindleSpeedOverride::Default;

--- a/Grbl_Esp32/src/Limits.cpp
+++ b/Grbl_Esp32/src/Limits.cpp
@@ -173,9 +173,9 @@ void limits_go_home(uint8_t cycle_mask) {
             }
             st_prep_buffer();  // Check and prep segment buffer. NOTE: Should take no longer than 200us.
             // Exit routines: No time to run protocol_execute_realtime() in this loop.
-            if (sys_rt_exec_state.bit.safetyDoor || sys_rt_exec_state.bit.reset || cycle_stop) {
+            if (sys_safetyDoor || sys_reset || sys_cycleStop) {
                 ExecState rt_exec_state;
-                rt_exec_state.value = sys_rt_exec_state.value;
+                rt_exec_state.value = sys_get_rt_exec_state().value;
                 // Homing failure condition: Reset issued during cycle.
                 if (rt_exec_state.bit.reset) {
                     sys_rt_exec_alarm = ExecAlarm::HomingFailReset;
@@ -189,7 +189,7 @@ void limits_go_home(uint8_t cycle_mask) {
                     sys_rt_exec_alarm = ExecAlarm::HomingFailPulloff;
                 }
                 // Homing failure condition: Limit switch not found during approach.
-                if (approach && cycle_stop) {
+                if (approach && rt_exec_state.bit.cycleStop) {
                     sys_rt_exec_alarm = ExecAlarm::HomingFailApproach;
                 }
 
@@ -200,7 +200,7 @@ void limits_go_home(uint8_t cycle_mask) {
                     return;
                 } else {
                     // Pull-off motion complete. Disable CYCLE_STOP from executing.
-                    cycle_stop = false;
+                    sys_cycleStop = false;
                     break;
                 }
             }
@@ -343,7 +343,7 @@ void limits_soft_check(float* target) {
         // workspace volume so just come to a controlled stop so position is not lost. When complete
         // enter alarm mode.
         if (sys.state == State::Cycle) {
-            sys_rt_exec_state.bit.feedHold = true;
+            sys_feedHold = true;
             do {
                 protocol_execute_realtime();
                 if (sys.abort) {

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -414,7 +414,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
     // Activate the probing state monitor in the stepper module.
     sys_probe_state = Probe::Active;
     // Perform probing cycle. Wait here until probe is triggered or motion completes.
-    sys_rt_exec_state.bit.cycleStart = true;
+    sys_cycleStart = true;
     do {
         protocol_execute_realtime();
         if (sys.abort) {
@@ -498,8 +498,8 @@ void mc_override_ctrl_update(uint8_t override_state) {
 // realtime abort command and hard limits. So, keep to a minimum.
 void mc_reset() {
     // Only this function can set the system reset. Helps prevent multiple kill calls.
-    if (!sys_rt_exec_state.bit.reset) {
-        sys_rt_exec_state.bit.reset = true;
+    if (!sys_reset) {
+        sys_reset = true;
         // Kill spindle and coolant.
         spindle->stop();
         coolant_stop();

--- a/Grbl_Esp32/src/Probe.cpp
+++ b/Grbl_Esp32/src/Probe.cpp
@@ -60,6 +60,6 @@ void probe_state_monitor() {
     if (probe_get_state() ^ is_probe_away) {
         sys_probe_state = Probe::Off;
         memcpy(sys_probe_position, sys_position, sizeof(sys_position));
-        sys_rt_exec_state.bit.motionCancel = true;
+        sys_motionCancel = true;
     }
 }

--- a/Grbl_Esp32/src/ProcessSettings.cpp
+++ b/Grbl_Esp32/src/ProcessSettings.cpp
@@ -273,7 +273,7 @@ Error home_c(const char* value, WebUI::AuthenticationLevel auth_level, WebUI::ES
     return home(bit(C_AXIS));
 }
 Error sleep_grbl(const char* value, WebUI::AuthenticationLevel auth_level, WebUI::ESPResponseStream* out) {
-    sys_rt_exec_state.bit.sleep = true;
+    sys_sleep = true;
     return Error::Ok;
 }
 Error get_report_build_info(const char* value, WebUI::AuthenticationLevel auth_level, WebUI::ESPResponseStream* out) {

--- a/Grbl_Esp32/src/Serial.cpp
+++ b/Grbl_Esp32/src/Serial.cpp
@@ -251,17 +251,17 @@ void execute_realtime_command(Cmd command, uint8_t client) {
             report_realtime_status(client);  // direct call instead of setting flag
             break;
         case Cmd::CycleStart:
-            sys_rt_exec_state.bit.cycleStart = true;
+            sys_cycleStart = true;
             break;
         case Cmd::FeedHold:
-            sys_rt_exec_state.bit.feedHold = true;
+            sys_feedHold = true;
             break;
         case Cmd::SafetyDoor:
-            sys_rt_exec_state.bit.safetyDoor = true;
+            sys_safetyDoor = true;
             break;
         case Cmd::JogCancel:
             if (sys.state == State::Jog) {  // Block all other states from invoking motion cancel.
-                sys_rt_exec_state.bit.motionCancel = true;
+                sys_motionCancel = true;
             }
             break;
         case Cmd::DebugReport:

--- a/Grbl_Esp32/src/Stepper.cpp
+++ b/Grbl_Esp32/src/Stepper.cpp
@@ -265,7 +265,7 @@ static void stepper_pulse_func() {
                     spindle->set_rpm(0);
                 }
             }
-            cycle_stop = true;
+            sys_cycleStop = true;
             return;  // Nothing to do but exit.
         }
     }

--- a/Grbl_Esp32/src/System.cpp
+++ b/Grbl_Esp32/src/System.cpp
@@ -26,10 +26,18 @@ system_t               sys;
 int32_t                sys_position[MAX_N_AXIS];        // Real-time machine (aka home) position vector in steps.
 int32_t                sys_probe_position[MAX_N_AXIS];  // Last probe position in machine coordinates and steps.
 volatile Probe         sys_probe_state;                 // Probing state value.  Used to coordinate the probing cycle with stepper ISR.
-volatile ExecState     sys_rt_exec_state;  // Global realtime executor bitflag variable for state management. See EXEC bitmasks.
 volatile ExecAlarm     sys_rt_exec_alarm;  // Global realtime executor bitflag variable for setting various alarms.
 volatile ExecAccessory sys_rt_exec_accessory_override;  // Global realtime executor bitflag variable for spindle/coolant overrides.
-volatile bool          cycle_stop;                      // For state transitions, instead of bitflag
+
+volatile bool          sys_statusReport;        // For state transitions, instead of bitflag
+volatile bool          sys_cycleStart;
+volatile bool          sys_cycleStop;
+volatile bool          sys_feedHold;
+volatile bool          sys_reset;
+volatile bool          sys_safetyDoor;
+volatile bool          sys_motionCancel;
+volatile bool          sys_sleep;
+
 #ifdef DEBUG
 volatile bool sys_rt_exec_debug;
 #endif
@@ -251,11 +259,11 @@ void system_exec_control_pin(ControlPins pins) {
         grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Reset via control pin");
         mc_reset();
     } else if (pins.bit.cycleStart) {
-        sys_rt_exec_state.bit.cycleStart = true;
+        sys_cycleStart = true;
     } else if (pins.bit.feedHold) {
-        sys_rt_exec_state.bit.feedHold = true;
+        sys_feedHold = true;
     } else if (pins.bit.safetyDoor) {
-        sys_rt_exec_state.bit.safetyDoor = true;
+        sys_safetyDoor = true;
     } else if (pins.bit.macro0) {
         user_defined_macro(0);  // function must be implemented by user
     } else if (pins.bit.macro1) {
@@ -327,6 +335,21 @@ uint8_t sys_calc_pwm_precision(uint32_t freq) {
 
     return precision - 1;
 }
+
+ExecState sys_get_rt_exec_state() {
+    ExecState result;
+    result.value = 0;
+    result.bit.statusReport = sys_statusReport;
+    result.bit.cycleStart = sys_cycleStart;
+    result.bit.cycleStop = sys_cycleStop;
+    result.bit.feedHold = sys_feedHold;
+    result.bit.reset = sys_reset;
+    result.bit.safetyDoor = sys_safetyDoor;
+    result.bit.motionCancel = sys_motionCancel;
+    result.bit.sleep = sys_sleep;
+    return result;
+}
+
 void __attribute__((weak)) user_defined_macro(uint8_t index) {
     // must be in Idle
     if (sys.state != State::Idle) {

--- a/Grbl_Esp32/src/System.h
+++ b/Grbl_Esp32/src/System.h
@@ -131,13 +131,23 @@ extern int32_t sys_position[MAX_N_AXIS];        // Real-time machine (aka home) 
 extern int32_t sys_probe_position[MAX_N_AXIS];  // Last probe position in machine coordinates and steps.
 
 extern volatile Probe         sys_probe_state;    // Probing state value.  Used to coordinate the probing cycle with stepper ISR.
-extern volatile ExecState     sys_rt_exec_state;  // Global realtime executor bitflag variable for state management. See EXEC bitmasks.
 extern volatile ExecAlarm     sys_rt_exec_alarm;  // Global realtime executor bitflag variable for setting various alarms.
 extern volatile ExecAccessory sys_rt_exec_accessory_override;  // Global realtime executor bitflag variable for spindle/coolant overrides.
 extern volatile Percent       sys_rt_f_override;               // Feed override value in percent
 extern volatile Percent       sys_rt_r_override;               // Rapid feed override value in percent
 extern volatile Percent       sys_rt_s_override;               // Spindle override value in percent
-extern volatile bool          cycle_stop;
+
+// System executor bits. Used internally by realtime protocol as realtime command flags,
+// which notifies the main program to execute the specified realtime command asynchronously.
+extern volatile bool          sys_statusReport;
+extern volatile bool          sys_cycleStart;
+extern volatile bool          sys_cycleStop;
+extern volatile bool          sys_feedHold;
+extern volatile bool          sys_reset;
+extern volatile bool          sys_safetyDoor;
+extern volatile bool          sys_motionCancel;
+extern volatile bool          sys_sleep;
+
 #ifdef DEBUG
 extern volatile bool sys_rt_exec_debug;
 #endif
@@ -176,3 +186,4 @@ bool sys_set_analog(uint8_t io_num, float percent);
 void sys_analog_all_off();
 
 int8_t sys_get_next_PWM_chan_num();
+ExecState sys_get_rt_exec_state();


### PR DESCRIPTION
A simple fix for the race condition with `sys_rt_exec_state` that breaks out all the state bits into separate bools.

A few notes:

- I renamed the `cycle_stop` global that was broken out previously to be consistent with the newly-added bits.

- In the existing code, in three places (the main `protocol_exec_rt_system()` as well as the limit check loops in Limits.cpp and CoreXY.cpp) the ExecState is captured into a local copy which is then used in the if/else logic. To keep the functionality and structure the same, I made a `sys_get_rt_exec_state()` call in System.cpp that pulls all the global bools back into a bitfield for this purpose. This all should be functionally the same as before.
  
  Note that `sys_get_rt_exec_state()` includes the `cycle_stop` bit as it used to in the olden days, and I changed the if/else to check it that way for consistency. (This may make line 275 in Protocol.cpp look like a mistake at first glance, but it should be correct.)

- Previously there was some discussion on whether  `sys_get_rt_exec_state()` and the ExecState bitfield are necessary, but I feel it is a clean way to snapshot the current state in `protocol_exec_rt_system()` for the if/else logic to generate the next state.