### PR TITLE
cancel in-flight jog in mc_line() on jogCancel - v2

### DIFF
--- a/Grbl_Esp32/src/GCode.cpp
+++ b/Grbl_Esp32/src/GCode.cpp
@@ -1290,8 +1290,9 @@ Error gc_execute_line(char* line, uint8_t client) {
         pl_data->spindle_speed = gc_state.spindle_speed;
         pl_data->spindle       = gc_state.modal.spindle;
         pl_data->coolant       = gc_state.modal.coolant;
-        Error status           = jog_execute(pl_data, &gc_block);
-        if (status == Error::Ok) {
+        bool cancelledInflight = false;
+        Error status           = jog_execute(pl_data, &gc_block, &cancelledInflight);
+        if (status == Error::Ok && !cancelledInflight) {
             memcpy(gc_state.position, gc_block.values.xyz, sizeof(gc_block.values.xyz));
         }
         return status;

--- a/Grbl_Esp32/src/Grbl.cpp
+++ b/Grbl_Esp32/src/Grbl.cpp
@@ -107,6 +107,10 @@ static void reset_variables() {
     plan_sync_position();
     gc_sync_position();
     report_init_message(CLIENT_ALL);
+
+    // used to keep track of a jog command sent to mc_line() so we can cancel it.
+    // this is needed if a jogCancel comes along after we have already parsed a jog and it is in-flight.
+    sys_pl_data_inflight = NULL;
 }
 
 void run_once() {

--- a/Grbl_Esp32/src/Jog.cpp
+++ b/Grbl_Esp32/src/Jog.cpp
@@ -24,11 +24,13 @@
 #include "Grbl.h"
 
 // Sets up valid jog motion received from g-code parser, checks for soft-limits, and executes the jog.
-Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block) {
+// cancelledInflight will be set to true if was not added to parser due to a cancelJog.
+Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block, bool* cancelledInflight) {
     // Initialize planner data struct for jogging motions.
     // NOTE: Spindle and coolant are allowed to fully function with overrides during a jog.
     pl_data->feed_rate             = gc_block->values.f;
     pl_data->motion.noFeedOverride = 1;
+    pl_data->is_jog                = true;
 #ifdef USE_LINE_NUMBERS
     pl_data->line_number = gc_block->values.n;
 #endif
@@ -37,12 +39,18 @@ Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block) {
             return Error::TravelExceeded;
         }
     }
-// Valid jog command. Plan, set state, and execute.
+    // Valid jog command. Plan, set state, and execute.
+    bool added_to_planner = true;
 #ifndef USE_KINEMATICS
-    mc_line(gc_block->values.xyz, pl_data);
+    added_to_planner = mc_line(gc_block->values.xyz, pl_data);
 #else  // else use kinematics
     inverse_kinematics(gc_block->values.xyz, pl_data, gc_state.position);
 #endif
+
+    if (!added_to_planner) {
+        if (cancelledInflight) *cancelledInflight = true;
+        return Error::Ok;
+    }
 
     if (sys.state == State::Idle) {
         if (plan_get_current_block() != NULL) {  // Check if there is a block to execute.

--- a/Grbl_Esp32/src/Jog.h
+++ b/Grbl_Esp32/src/Jog.h
@@ -28,4 +28,5 @@
 const int JOG_LINE_NUMBER = 0;
 
 // Sets up valid jog motion received from g-code parser, checks for soft-limits, and executes the jog.
-Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block);
+// cancelledInflight will be set to true if was not added to parser due to a cancelJog.
+Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block, bool* cancelledInflight);

--- a/Grbl_Esp32/src/MotionControl.h
+++ b/Grbl_Esp32/src/MotionControl.h
@@ -36,7 +36,7 @@ const int PARKING_MOTION_LINE_NUMBER = 0;
 // unless invert_feed_rate is true. Then the feed_rate means that the motion should be completed in
 // (1 minute)/feed_rate time.
 void mc_line_kins(float* target, plan_line_data_t* pl_data, float* position);
-void mc_line(float* target, plan_line_data_t* pl_data);
+bool mc_line(float* target, plan_line_data_t* pl_data); // returns true if line was submitted to planner
 
 // Execute an arc in offset mode format. position == current xyz, target == target xyz,
 // offset == offset from current xyz, axis_XXX defines circle plane in tool space, axis_linear is

--- a/Grbl_Esp32/src/Planner.h
+++ b/Grbl_Esp32/src/Planner.h
@@ -91,6 +91,7 @@ typedef struct {
 #ifdef USE_LINE_NUMBERS
     int32_t line_number;  // Desired line number to report when executing.
 #endif
+    bool         is_jog;         // true if this was generated due to a jog command
 } plan_line_data_t;
 
 // Initialize and reset the motion plan subsystem

--- a/Grbl_Esp32/src/Protocol.cpp
+++ b/Grbl_Esp32/src/Protocol.cpp
@@ -567,6 +567,12 @@ static void protocol_exec_rt_suspend() {
         if (sys.abort) {
             return;
         }
+        // if a jogCancel comes in and we have a jog "in-flight" (parsed and handed over to mc_line()),
+        //  then we need to cancel it before it reaches the planner.  otherwise we may try to move way out of
+        //  normal bounds, especially with senders that issue a series of jog commands before sending a cancel.
+        if (sys.suspend.bit.jogCancel && sys_pl_data_inflight != NULL && ((plan_line_data_t*)sys_pl_data_inflight)->is_jog) {
+            sys_pl_data_inflight = NULL;
+        }
         // Block until initial hold is complete and the machine has stopped motion.
         if (sys.suspend.bit.holdComplete) {
             // Parking manager. Handles de/re-energizing, switch state checks, and parking motions for

--- a/Grbl_Esp32/src/System.cpp
+++ b/Grbl_Esp32/src/System.cpp
@@ -30,6 +30,7 @@ volatile ExecState     sys_rt_exec_state;  // Global realtime executor bitflag v
 volatile ExecAlarm     sys_rt_exec_alarm;  // Global realtime executor bitflag variable for setting various alarms.
 volatile ExecAccessory sys_rt_exec_accessory_override;  // Global realtime executor bitflag variable for spindle/coolant overrides.
 volatile bool          cycle_stop;                      // For state transitions, instead of bitflag
+volatile void*         sys_pl_data_inflight;            // holds a plan_line_data_t while mc_line has taken ownership of a line motion
 #ifdef DEBUG
 volatile bool sys_rt_exec_debug;
 #endif

--- a/Grbl_Esp32/src/System.h
+++ b/Grbl_Esp32/src/System.h
@@ -138,6 +138,7 @@ extern volatile Percent       sys_rt_f_override;               // Feed override 
 extern volatile Percent       sys_rt_r_override;               // Rapid feed override value in percent
 extern volatile Percent       sys_rt_s_override;               // Spindle override value in percent
 extern volatile bool          cycle_stop;
+extern volatile void*         sys_pl_data_inflight;            // holds a plan_line_data_t while mc_line has taken ownership of a line motion
 #ifdef DEBUG
 extern volatile bool sys_rt_exec_debug;
 #endif


### PR DESCRIPTION
### Cancel/hold misses jog move that is in-flight in mc_line()

When a `jogCancel` or `feedHold` arrives, the planner is emptied and gcode parser state resets to current position, which is good. But a next jog command could already be in-flight at this point, waiting in `mc_line()` as the machine decelerates, and with target position determined based on gcode that has been dropped due to the hold/cancel.

UGS causes this easily by sending a continuing series of incremental jog commands while holding down a jog direction button. These can accumulate the target position to a large number, and since a `jogCancel` or `feedHold` during `State::Jog` results in going back to `State::Idle`, that stuck in-flight move gets added to the planner with the large target value intact. The machine then moves and hits the endstop. This is especially obvious and problematic when UGS is set to a jog feedrate much larger than the axis can support (since that in-flight move gets a much larger and easily out-of-bounds target position).

My simple fix for this is to create a global variable that tracks an in-flight command in `mc_line()`. In `protocol_exec_rt_suspend()` I look for `sys.suspend.bit.jogCancel` being true, and if the in-flight command is a jog, I set a flag that `mc_line()` will notice and not add it to the planner. I added an `is_jog` flag to `plan_line_data_t` to track whether it’s a jog, and a return bool from `mc_line()` to signal it dropped the command so that `jog_execute()` can signal back to `gc_execute_line()` that it was dropped and skip the updating of `gc_state.position`.

I did not touch the kinematic path to mc_line().

This will only catch these in-flight moves if `protocol_execute_realtime()` is called when the move has entered `mc_line()`. Currently that should catch all the cases of this happening, but perhaps some future scenarios or custom code could call `protocol_execute_realtime()` after a gcode line was parsed but before getting to `mc_line()`. But I guess in that case it is no different than how it behaves without the fix.