### PR TITLE
fix soft limits for kinetics machines. fix corexy maths

### DIFF
--- a/Grbl_Esp32/src/Config.h
+++ b/Grbl_Esp32/src/Config.h
@@ -61,6 +61,8 @@ Some features should not be changed. See notes below.
 
 #define USE_RMT_STEPS
 
+#define VERBOSE_LOGGING
+
 // Include the file that loads the machine-specific config file.
 // machine.h must be edited to choose the desired file.
 #include "Machine.h"
@@ -98,11 +100,11 @@ const int MAX_N_AXIS = 6;
 //#define CONNECT_TO_SSID  "your SSID"
 //#define SSID_PASSWORD  "your SSID password"
 //CONFIGURE_EYECATCH_BEGIN (DO NOT MODIFY THIS LINE)
-#define ENABLE_BLUETOOTH  // enable bluetooth
+// #define ENABLE_BLUETOOTH  // enable bluetooth
 
-#define ENABLE_SD_CARD  // enable use of SD Card to run jobs
+// #define ENABLE_SD_CARD  // enable use of SD Card to run jobs
 
-#define ENABLE_WIFI  //enable wifi
+// #define ENABLE_WIFI  //enable wifi
 
 #if defined(ENABLE_WIFI) || defined(ENABLE_BLUETOOTH)
 #    define WIFI_OR_BLUETOOTH
@@ -112,7 +114,7 @@ const int MAX_N_AXIS = 6;
 #define ENABLE_OTA                 //enable OTA
 #define ENABLE_TELNET              //enable telnet
 #define ENABLE_TELNET_WELCOME_MSG  //display welcome string when connect to telnet
-#define ENABLE_MDNS                //enable mDNS discovery
+// #define ENABLE_MDNS                //enable mDNS discovery
 #define ENABLE_SSDP                //enable UPNP discovery
 #define ENABLE_NOTIFICATIONS       //enable notifications
 

--- a/Grbl_Esp32/src/Jog.cpp
+++ b/Grbl_Esp32/src/Jog.cpp
@@ -29,19 +29,18 @@ Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block) {
     // NOTE: Spindle and coolant are allowed to fully function with overrides during a jog.
     pl_data->feed_rate             = gc_block->values.f;
     pl_data->motion.noFeedOverride = 1;
+
 #ifdef USE_LINE_NUMBERS
     pl_data->line_number = gc_block->values.n;
 #endif
-    if (soft_limits->get()) {
-        if (limitsCheckTravel(gc_block->values.xyz)) {
-            return Error::TravelExceeded;
-        }
-    }
-// Valid jog command. Plan, set state, and execute.
-#ifndef USE_KINEMATICS
-    mc_line(gc_block->values.xyz, pl_data);
-#else  // else use kinematics
-    inverse_kinematics(gc_block->values.xyz, pl_data, gc_state.position);
+#ifdef VERBOSE_LOGGING
+    grbl_msg_sendf(CLIENT_SERIAL,
+                           MsgLevel::Info,
+                           "jog %.2f %.2f",
+                           gc_block->values.xyz[X_AXIS], gc_block->values.xyz[Y_AXIS]
+                           );
+    
+    mc_line_kins(gc_block->values.xyz, pl_data, gc_state.position);
 #endif
 
     if (sys.state == State::Idle) {

--- a/Grbl_Esp32/src/Limits.cpp
+++ b/Grbl_Esp32/src/Limits.cpp
@@ -280,6 +280,13 @@ void limits_init() {
                     grbl_msg_sendf(
                         CLIENT_SERIAL, MsgLevel::Info, "%s limit switch on pin %s", reportAxisNameMsg(axis, gang_index), pinName(pin).c_str());
                 }
+            #ifdef VERBOSE_LOGGING
+            } else {
+                grbl_msg_sendf(CLIENT_SERIAL,
+                           MsgLevel::Info,
+                           "limits_init, no pin %s %d",
+                           reportAxisNameMsg(axis, gang_index), gang_index);
+            #endif
             }
         }
     }
@@ -396,9 +403,14 @@ bool limitsCheckTravel(float* target) {
     uint8_t idx;
     auto    n_axis = number_axis->get();
     for (idx = 0; idx < n_axis; idx++) {
-        float max_mpos, min_mpos;
-
         if (target[idx] < limitsMinPosition(idx) || target[idx] > limitsMaxPosition(idx)) {
+            #ifdef VERBOSE_LOGGING
+             grbl_msg_sendf(CLIENT_SERIAL,
+                           MsgLevel::Info,
+                           "limitsCheckTravel found axis %d target (%.2f %.2f %.2f)  min %.2f max %.2f",
+                           idx, target[X_AXIS], target[Y_AXIS], target[Z_AXIS], limitsMinPosition(idx), limitsMaxPosition(idx) 
+                           );
+            #endif
             return true;
         }
     }

--- a/Grbl_Esp32/src/Machine.h
+++ b/Grbl_Esp32/src/Machine.h
@@ -8,8 +8,8 @@
 // !!! For initial testing, start with test_drive.h which disables
 // all I/O pins
 // #include "Machines/atari_1020.h"
-#    include "Machines/test_drive.h"
-
+// #    include "Machines/test_drive.h"
+#include "Machines/midtbot.h"
 // !!! For actual use, change the line above to select a board
 // from Machines/, for example:
 // #include "Machines/3axis_v4.h"

--- a/Grbl_Esp32/src/Machines/midtbot.h
+++ b/Grbl_Esp32/src/Machines/midtbot.h
@@ -43,16 +43,15 @@
 #define X_DIRECTION_PIN GPIO_NUM_26
 #define Y_DIRECTION_PIN GPIO_NUM_25
 
-#define STEPPERS_DISABLE_PIN GPIO_NUM_13
+// #define STEPPERS_DISABLE_PIN GPIO_NUM_16
 
 #define X_LIMIT_PIN     GPIO_NUM_2
 #define Y_LIMIT_PIN     GPIO_NUM_4
 
 #define Z_SERVO_PIN             GPIO_NUM_27
+// #define Z_SERVO_PIN             GPIO_NUM_13
 
 // Set $Homing/Cycle0=Y and $Homing/Cycle1=X
-
-#define SPINDLE_TYPE SpindleType::NONE
 
 // defaults
 #define DEFAULT_HOMING_CYCLE_0      bit(Z_AXIS)
@@ -76,7 +75,7 @@
 #define DEFAULT_ARC_TOLERANCE       0.002 // mm
 #define DEFAULT_REPORT_INCHES       0 // false
 
-#define DEFAULT_SOFT_LIMIT_ENABLE 0 // false
+#define DEFAULT_SOFT_LIMIT_ENABLE 1 // false
 #define DEFAULT_HARD_LIMIT_ENABLE 0  // false
 
 #define DEFAULT_HOMING_ENABLE           1


### PR DESCRIPTION
Fixing soft limits for corexy. There was an issue here where values could get converted twice by the kinematics functions. By moving it to mc_line_kins the value has not yet been altered. 

Fixing corexy maths. I found the maths was not quite right. 

I have tested these fixes with UGS which now almost behaves completely properly (imho). There is one more issue where if you stop UGS executing a gcode file part way through, and then send a G0 message, the value is somehow caulculated wrong or something. I have always had this problem with grbl_esp32 so its nothing I have added. I hope to track it down soon. 

