### PR TITLE
TMC2209 Stallguard

### DIFF
--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -23,7 +23,7 @@
 // Grbl versioning system
 
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20210101";
+const char* const GRBL_VERSION_BUILD = "20210121";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/src/Machines/TMC2209_4x.h
+++ b/Grbl_Esp32/src/Machines/TMC2209_4x.h
@@ -1,0 +1,89 @@
+#pragma once
+// clang-format off
+
+/*
+    TMC2209_4x.h
+    https://github.com/FYSETC/FYSETC-E4
+
+    2020-12-29 B. Dring
+
+    This is a machine definition file to use the FYSTEC E4 3D Printer controller
+    This is a 4 motor controller. This is setup for XYZA, but XYYZ, could also be used.
+    There are 5 inputs
+    The controller has outputs for a Fan, Hotbed and Extruder. There are mapped to
+    spindle, mist and flood coolant to drive an external relay.
+
+    Grbl_ESP32 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Grbl is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define MACHINE_NAME            "TMC2209 4x Controller"
+
+#define N_AXIS 4
+
+#define TRINAMIC_UART_RUN_MODE       TrinamicUartMode :: StealthChop
+#define TRINAMIC_UART_HOMING_MODE    TrinamicUartMode :: StallGuard
+
+#define TMC_UART                UART_NUM_1
+#define TMC_UART_RX             GPIO_NUM_21
+#define TMC_UART_TX             GPIO_NUM_22   
+
+#define X_TRINAMIC_DRIVER       2209
+#define X_STEP_PIN              GPIO_NUM_26
+#define X_DIRECTION_PIN         GPIO_NUM_27
+#define X_RSENSE                TMC2209_RSENSE_DEFAULT
+#define X_DRIVER_ADDRESS        0
+#define DEFAULT_X_MICROSTEPS    16
+
+#define Y_TRINAMIC_DRIVER       2209
+#define Y_STEP_PIN              GPIO_NUM_33
+#define Y_DIRECTION_PIN         GPIO_NUM_32
+#define Y_RSENSE                TMC2209_RSENSE_DEFAULT
+#define Y_DRIVER_ADDRESS        1
+#define DEFAULT_Y_MICROSTEPS    16
+
+#define Z_TRINAMIC_DRIVER       2209
+#define Z_STEP_PIN              GPIO_NUM_2
+#define Z_DIRECTION_PIN         GPIO_NUM_4
+#define Z_RSENSE                TMC2209_RSENSE_DEFAULT
+#define Z_DRIVER_ADDRESS        2
+#define DEFAULT_Z_MICROSTEPS    16
+
+#define A_TRINAMIC_DRIVER       2209
+#define A_STEP_PIN              GPIO_NUM_16
+#define A_DIRECTION_PIN         GPIO_NUM_17
+#define A_RSENSE                TMC2209_RSENSE_DEFAULT
+#define A_DRIVER_ADDRESS        3
+#define DEFAULT_A_MICROSTEPS    16
+
+#define X_LIMIT_PIN             GPIO_NUM_36
+#define Y_LIMIT_PIN             GPIO_NUM_39
+#define Z_LIMIT_PIN             GPIO_NUM_34
+#define PROBE_PIN               GPIO_NUM_35
+
+// OK to comment out to use pin for other features
+#define STEPPERS_DISABLE_PIN    GPIO_NUM_25
+
+
+// https://github.com/bdring/6-Pack_CNC_Controller/wiki/4x-5V-Buffered-Output-Module
+// https://github.com/bdring/6-Pack_CNC_Controller/wiki/Quad-MOSFET-Module
+#define USER_DIGITAL_PIN_0      GPIO_NUM_14 //  M62 M63
+#define USER_DIGITAL_PIN_1      GPIO_NUM_13 //  M62 M63
+#define USER_DIGITAL_PIN_2      GPIO_NUM_15 //  M62 M63
+#define USER_DIGITAL_PIN_3      GPIO_NUM_12 //  M62 M63
+
+
+// ===================== defaults ======================
+// https://github.com/bdring/Grbl_Esp32/wiki/Setting-Defaults
+
+#define DEFAULT_INVERT_PROBE_PIN 1

--- a/Grbl_Esp32/src/Motors/TrinamicDriver.cpp
+++ b/Grbl_Esp32/src/Motors/TrinamicDriver.cpp
@@ -258,7 +258,7 @@ namespace Motors {
                 tmcstepper->THIGH(calc_tstep(homing_feed_rate->get(), 60.0));
                 tmcstepper->sfilt(1);
                 tmcstepper->diag1_stall(true);  // stallguard i/o is on diag1
-                tmcstepper->sgt(axis_settings[_axis_index]->stallguard->get());
+                tmcstepper->sgt(constrain(axis_settings[_axis_index]->stallguard->get(), -64, 63));
                 break;
             default:
                 grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "TRINAMIC_MODE_UNDEFINED");
@@ -286,7 +286,7 @@ namespace Motors {
                        tmcstepper->stallguard(),
                        tmcstepper->sg_result(),
                        feedrate,
-                       axis_settings[_axis_index]->stallguard->get());
+                       constrain(axis_settings[_axis_index]->stallguard->get(), -64, 63));
 
         TMC2130_n ::DRV_STATUS_t status { 0 };  // a useful struct to access the bits.
         status.sr = tmcstepper->DRV_STATUS();

--- a/Grbl_Esp32/src/Motors/TrinamicUartDriver.h
+++ b/Grbl_Esp32/src/Motors/TrinamicUartDriver.h
@@ -98,7 +98,7 @@ namespace Motors {
     private:
         uint32_t calc_tstep(float speed, float percent);  //TODO: see if this is useful/used.
 
-        TMC2208Stepper*  tmcstepper;  // all other driver types are subclasses of this one
+        TMC2209Stepper*  tmcstepper;  // all other driver types are subclasses of this one
         TrinamicUartMode _homing_mode;
         uint16_t         _driver_part_number;  // example: use 2209 for TMC2209
         float            _r_sense;

--- a/Grbl_Esp32/src/SettingsDefinitions.cpp
+++ b/Grbl_Esp32/src/SettingsDefinitions.cpp
@@ -258,7 +258,7 @@ void make_settings() {
     for (axis = MAX_N_AXIS - 1; axis >= 0; axis--) {
         def = &axis_defaults[axis];
         auto setting =
-            new IntSetting(EXTENDED, WG, makeGrblName(axis, 170), makename(def->name, "StallGuard"), def->stallguard, -64, 63, postMotorSetting);
+            new IntSetting(EXTENDED, WG, makeGrblName(axis, 170), makename(def->name, "StallGuard"), def->stallguard, -64, 255, postMotorSetting);
         setting->setAxis(axis);
         axis_settings[axis]->stallguard = setting;
     }


### PR DESCRIPTION
- Added StallGuard homing support to TMC2209 (UART)
- Killed off TMC2208 for now. Too many conflicts with TMC2209. Will return with Diamond motor class hierarchy
- Increase StallGuard setting range for TMC2209. Constrianed in each class to actual limits
- Added a machine def to test TMC2209