### PR TITLE
Fixed busy flag in Stepper.cpp by using an atomic compare/exchange op.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __vm/
 *.vcxproj.filters
 *.suo
 Grbl_Esp32.ino.cpp
+/packages

--- a/Grbl_Esp32/src/Spindles/NullSpindle.h
+++ b/Grbl_Esp32/src/Spindles/NullSpindle.h
@@ -42,6 +42,10 @@ namespace Spindles {
         void         stop() override;
         void         config_message() override;
 
+        bool         inLaserMode() override {
+            return laser_mode->get();  // can use M4 (CCW) laser mode.
+        }
+
         virtual ~Null() {}
     };
 }

--- a/Grbl_Esp32/src/Stepper.cpp
+++ b/Grbl_Esp32/src/Stepper.cpp
@@ -28,6 +28,8 @@
 
 #define ISR_PROFILE_PIN GPIO_NUM_25  // used to determine ISR duration on logic analyzer
 
+#include <atomic>
+
 // Stores the planner block Bresenham algorithm execution data for the segments in the segment
 // buffer. Normally, this buffer is partially in-use, but, for the worst case scenario, it will
 // never exceed the number of accessible stepper buffer segments (SEGMENT_BUFFER_SIZE-1).
@@ -84,7 +86,7 @@ static uint8_t          segment_buffer_head;
 static uint8_t          segment_next_head;
 
 // Used to avoid ISR nesting of the "Stepper Driver Interrupt". Should never occur though.
-static volatile uint8_t busy;
+static std::atomic<bool> busy;
 
 // Pointers for the step segment being prepped from the planner buffer. Accessed only by the
 // main program. Pointers may be planning segments or planner blocks ahead of what being executed.
@@ -202,19 +204,21 @@ static void stepper_pulse_func();
 // TODO: Replace direct updating of the int32 position counters in the ISR somehow. Perhaps use smaller
 // int8 variables and update position counters only when a segment completes. This can get complicated
 // with probing and homing cycles that require true real-time positions.
-void IRAM_ATTR onStepperDriverTimer(void* para) {  // ISR It is time to take a step
-    //const int timer_idx = (int)para;  // get the timer index
+void IRAM_ATTR onStepperDriverTimer(void* para) {
+    // Timer ISR, normally takes a step.
+    //
+    // When handling an interrupt within an interrupt serivce routine (ISR), the interrupt status bit
+    // needs to be explicitly cleared.
     TIMERG0.int_clr_timers.t0 = 1;
-    if (busy) {
-        *(uint32_t*)0 = 0;
-        //return;  // The busy-flag is used to avoid reentering this interrupt
+
+    bool expected = false;
+    if (busy.compare_exchange_strong(expected, true)) {
+        stepper_pulse_func();
+
+        TIMERG0.hw_timer[STEP_TIMER_INDEX].config.alarm_en = TIMER_ALARM_EN;
+
+        busy.store(false);
     }
-    busy = true;
-
-    stepper_pulse_func();
-
-    TIMERG0.hw_timer[STEP_TIMER_INDEX].config.alarm_en = TIMER_ALARM_EN;
-    busy                                               = false;
 }
 
 /**
@@ -353,6 +357,8 @@ static void stepper_pulse_func() {
 }
 
 void stepper_init() {
+    busy.store(false);
+
     grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Axis count %d", number_axis->get());
     grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "%s", stepper_names[current_stepper]);
 
@@ -420,7 +426,6 @@ void st_reset() {
     segment_buffer_tail = 0;
     segment_buffer_head = 0;  // empty = tail
     segment_next_head   = 1;
-    busy                = false;
     st.step_outbits     = 0;
     st.dir_outbits      = 0;  // Initialize direction bits to default.
     // TODO do we need to turn step pins off?
@@ -430,7 +435,6 @@ void st_reset() {
 void st_go_idle() {
     // Disable Stepper Driver Interrupt. Allow Stepper Port Reset Interrupt to finish, if active.
     Stepper_Timer_Stop();
-    busy = false;
 
     // Set stepper driver idle state, disabled or enabled, depending on settings and circumstances.
     if (((stepper_idle_lock_time->get() != 0xff) || sys_rt_exec_alarm != ExecAlarm::None || sys.state == State::Sleep) &&


### PR DESCRIPTION
2 small changes. First added laser mode to null spindle for testing. It's not interesting. The other is described below.

We basically have 2 calls to `stepper_pulse_func`, and we do NOT want concurrency there.

One of them is from I2S, which actually calls the function from a critical section (mutex). In other words, there is no issue there.
The other is from `onStepperDriverTimer`, which uses a `busy` flag to check if it's already in use.

Even though `busy` was already volatile, that doesn't mean that the `if` ... `busy = true` is atomic. Other threads might mess things up, so it's better to just get it right. `std::atomic<bool>` with `compare_exchange_strong` does exactly that.