### PR TITLE
Set SD card state to idle when file is not found

### DIFF
--- a/Grbl_Esp32/src/WebUI/WebServer.cpp
+++ b/Grbl_Esp32/src/WebUI/WebServer.cpp
@@ -1331,6 +1331,7 @@ namespace WebUI {
             s += path;
             s += " does not exist on SD Card\"}";
             _webserver->send(200, "application/json", s);
+            set_sd_state(SDCARD_IDLE);
             SD.end();
             return;
         }


### PR DESCRIPTION
After requesting a file that does not exist on the SD card, the SD card state is stuck in the busy state because of the premature return statement.

This sets the state back to idle before returning.