### PR TITLE
Fix VFD speed change from ISR

### DIFF
--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -22,7 +22,7 @@
 
 // Grbl versioning system
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20210308";
+const char* const GRBL_VERSION_BUILD = "20210311";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/src/Spindles/VFDSpindle.cpp
+++ b/Grbl_Esp32/src/Spindles/VFDSpindle.cpp
@@ -406,6 +406,11 @@ namespace Spindles {
 
         if (_current_state != state) {  // already at the desired state. This function gets called a lot.
             set_mode(state, critical);  // critical if we are in a job
+
+            if (rpm != 0 && (rpm < _min_rpm || rpm > _max_rpm)) {
+                grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "VFD: Requested speed %d outside range:(%d,%d)", rpm, _min_rpm, _max_rpm);
+            }
+
             set_rpm(rpm);
 
             if (state == SpindleState::Disable) {
@@ -422,6 +427,10 @@ namespace Spindles {
             }
         } else {
             if (_current_rpm != rpm) {
+                if (rpm != 0 && (rpm < _min_rpm || rpm > _max_rpm)) {
+                    grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "VFD: Requested speed %d outside range:(%d,%d)", rpm, _min_rpm, _max_rpm);
+                }
+
                 set_rpm(rpm);
 
                 if (rpm > _current_rpm) {
@@ -524,10 +533,11 @@ namespace Spindles {
         // apply override
         rpm = rpm * sys.spindle_speed_ovr / 100;  // Scale by spindle speed override value (uint8_t percent)
 
-        if (rpm < _min_rpm || rpm > _max_rpm) {
-            grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "VFD: Requested speed %d outside range:(%d,%d)", rpm, _min_rpm, _max_rpm);
+        if (rpm != 0 && (rpm < _min_rpm || rpm > _max_rpm)) {
+            // NOTE: Don't add a info message here; this method is called from the stepper_pulse_func ISR method, so
+            // emitting debug information could crash the ESP32.
+
             rpm = constrain(rpm, _min_rpm, _max_rpm);
-            grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "VFD: Requested speed changed to %d", rpm);
         }
 
         // apply limits
@@ -554,7 +564,6 @@ namespace Spindles {
         ModbusCommand rpm_cmd;
         rpm_cmd.msg[0] = VFD_RS485_ADDR;
 
-        
         set_speed_command(rpm, rpm_cmd);
 
         rpm_cmd.critical = (rpm == 0);


### PR DESCRIPTION
tl;dr: ISR's don't work well with `grbl_msg_sendf`.

The long story... 

Basically if you do a command like homing that calls motion control, it sets the RPM to value=0 along the homing path. This triggers `set_rpm(0)`, which checks the bounds of the RPM. If 0 is not in bounds, it clamps it to the bounds, sets the RPM and outputs an info message. However, the '0' is not really the issue here, the motion control call is; even with 0, it shouldn't crash.

Well it does. Unfortunately this all happens inside an ISR, which is where this goes wrong. In other words: the last minute change with the info message was a bad idea.

The info message is very helpful though, so we should actually use that when we have the time, -say- when we're calling `set_state` and not `set_rpm`. 

If not, the current code will crash. This PR fixes that crash.

Stack trace:

0x40182e2a: __ssprint_r at ../../../.././newlib/libc/stdio/vfprintf.c line 290
0x4017905e: _svfprintf_r at ../../../.././newlib/libc/stdio/vfprintf.c line 1774
0x4018080e: _vsnprintf_r at ../../../.././newlib/libc/stdio/vsnprintf.c line 72
0x4018084a: vsnprintf at ../../../.././newlib/libc/stdio/vsnprintf.c line 41
0x400d9572: grbl_sendf(unsigned char, char const*, ...) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Report.cpp line 102
0x400d962e: grbl_msg_sendf(unsigned char, MsgLevel, char const*, ...) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Report.cpp line 136
0x400de079: Spindles::VFD::set_rpm(unsigned int) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Spindles/VFDSpindle.cpp line 530
0x400df615: stepper_pulse_func() at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Stepper.cpp line 287
0x4008217a: onStepperDriverTimer(void*) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Stepper.cpp line 207
0x40081ff5: pinMode(uint8_t, uint8_t) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Pins.cpp line 38
0x400d4c29: limits_go_home(unsigned char) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Limits.cpp line 164
0x400d5361: mc_homing_cycle(unsigned char) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/MotionControl.cpp line 321
0x400d80df: home(int) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/ProcessSettings.cpp line 236
0x400d815d: home_z(char const*, WebUI::AuthenticationLevel, WebUI::ESPResponseStream*) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/ProcessSettings.cpp line 264
0x4022011d: GrblCommand::action(char*, WebUI::AuthenticationLevel, WebUI::ESPResponseStream*) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Settings.cpp line 725
0x400d7e19: do_command_or_setting(char const*, char*, WebUI::AuthenticationLevel, WebUI::ESPResponseStream*) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/ProcessSettings.cpp line 545
0x400d7fa3: system_execute_line(char*, WebUI::ESPResponseStream*, WebUI::AuthenticationLevel) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/ProcessSettings.cpp line 607
0x400d7fd6: system_execute_line(char*, unsigned char, WebUI::AuthenticationLevel) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/ProcessSettings.cpp line 612
0x400d843c: execute_line(char*, unsigned char, WebUI::AuthenticationLevel) at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Protocol.cpp line 85
0x400d8ea9: protocol_main_loop() at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Protocol.cpp line 175
0x400d4707: run_once() at /var/folders/6s/n4h1wc250lj4jbq3z1qmx15w0000gn/T/arduino_build_264315/sketch/src/Grbl.cpp line 114
0x400d2ebf: loop() at /Users/etienne/Documents/eGRBL_ESP32/Grbl_Esp32-main/Grbl_Esp32/Grbl_Esp32.ino line 28
0x400fc2e0: loopTask(void*) at /Users/etienne/Library/Arduino15/packages/esp32/hardware/esp32/1.0.5/cores/esp32/main.cpp line 37
0x400929e6: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c line 143

