### PR TITLE
Logo for web use

### DIFF
--- a/doc/img/grbl-esp32.svg
+++ b/doc/img/grbl-esp32.svg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="595.08667"
+   height="378.95062"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="grbl-esp32.svg"
+   viewBox="0 0 557.89373 355.26621">
+  <metadata
+     id="metadata97">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2000"
+     inkscape:window-height="1016"
+     id="namedview95"
+     showgrid="false"
+     inkscape:zoom="0.63429569"
+     inkscape:cx="-191.96199"
+     inkscape:cy="143.71159"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g21"
+     inkscape:document-rotation="0" />
+  <desc
+     id="desc4">/Users/chamnit/Dropbox/documents/OHS/Logo/Grbl.DXF - scale = 58.043118, origin = (0.000000, 0.000000), auto = True</desc>
+  <defs
+     id="defs6">
+    <marker
+       id="DistanceX"
+       orient="auto"
+       refX="0"
+       refY="0"
+       style="overflow:visible">
+      <path
+         d="M 3,-3 -3,3 M 0,-5 V 5"
+         style="stroke:#000000;stroke-width:0.5"
+         id="path9" />
+    </marker>
+    <pattern
+       height="8"
+       id="Hatch"
+       patternUnits="userSpaceOnUse"
+       width="8"
+       x="0"
+       y="0">
+      <path
+         d="M8 4 l-4,4"
+         linecap="square"
+         stroke="#000000"
+         stroke-width="0.25"
+         id="path12" />
+      <path
+         d="M6 2 l-4,4"
+         linecap="square"
+         stroke="#000000"
+         stroke-width="0.25"
+         id="path14" />
+      <path
+         d="M4 0 l-4,4"
+         linecap="square"
+         stroke="#000000"
+         stroke-width="0.25"
+         id="path16" />
+    </pattern>
+    <symbol
+       id="*Model_Space" />
+    <symbol
+       id="*Paper_Space" />
+    <symbol
+       id="*Paper_Space0" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="0"
+     id="g21"
+     transform="translate(-93.203613,-346.53518)">
+    <g
+       id="g3562"
+       transform="matrix(0.74854703,0,0,0.74854703,93.578346,130.5299)">
+      <path
+         sodipodi:nodetypes="ccscccccc"
+         inkscape:connector-curvature="0"
+         id="path45"
+         style="fill:#000000;stroke:#000000;stroke-linecap:round"
+         d="M 666.97027,519.20619 V 314.98125 c 0,-14.19819 -11.5099,-25.70806 -25.70807,-25.70806 -14.19818,0 -25.70808,11.50987 -25.70808,25.70806 v 204.22494 c 0,56.79271 46.03958,102.83229 102.83229,102.8323 l 25.70808,-25.70808 -25.70808,-25.70807 c -28.39635,0 -51.41614,-23.0198 -51.41614,-51.41615 z" />
+      <path
+         sodipodi:nodetypes="ccsccccccc"
+         inkscape:connector-curvature="0"
+         id="path61"
+         style="fill:#000000;stroke:#000000;stroke-linecap:round"
+         d="m 230.65284,519.20619 v 77.12422 c 0,14.19819 11.5099,25.70806 25.70807,25.70806 14.19818,0 25.70808,-11.50987 25.70808,-25.70806 v -77.12422 c 0,-28.39635 23.01979,-51.41615 51.41614,-51.41615 h 38.92203 V 416.3739 h -38.92203 c -56.7927,1e-5 -102.83228,46.03959 -102.83229,102.83229" />
+      <path
+         sodipodi:nodetypes="ccccssscccccsssc"
+         inkscape:connector-curvature="0"
+         id="path73"
+         style="fill:#000000;stroke:#000000;stroke-linecap:round"
+         d="m 487.73358,416.3739 h -38.92203 v 51.41614 h 38.92203 c 20.79587,0 39.54419,12.52721 47.50197,31.73975 7.95777,19.21249 3.55772,41.32642 -11.14711,56.03126 -14.70484,14.70483 -36.81877,19.10488 -56.03126,11.14711 -19.21254,-7.95778 -31.73975,-26.7061 -31.73975,-47.50197 V 314.98125 l -25.70808,-25.70807 -25.70807,25.70807 v 204.22494 c 0,41.59174 25.05442,79.08838 63.47948,95.00395 38.42499,15.91554 82.65286,7.11546 112.06254,-22.29421 29.40967,-29.40968 38.20976,-73.63755 22.29423,-112.06254 -15.91557,-38.42506 -53.41221,-63.47949 -95.00395,-63.47949" />
+      <path
+         sodipodi:nodetypes="cssscccscccsssccccc"
+         inkscape:connector-curvature="0"
+         id="path81"
+         style="fill:#000000;stroke:#000000;stroke-linecap:round"
+         d="m 102.8323,570.62234 c -20.795869,0 -39.544189,-12.52721 -47.501976,-31.73974 -7.95777,-19.21249 -3.557731,-41.32643 11.147104,-56.03126 14.704835,-14.70484 36.818772,-19.10489 56.031262,-11.14712 19.21254,7.95778 31.73975,26.7061 31.73975,47.50197 v 127.10072 c 0,28.39635 -23.01979,51.41615 -51.41614,51.41615 -14.192584,0.008 -25.693722,11.51549 -25.693722,25.70807 0,14.19258 11.501138,25.70007 25.693722,25.70807 56.7927,-10e-6 102.83228,-46.03959 102.83229,-102.83229 V 519.20619 c 0,-41.59174 -25.05443,-79.08838 -63.47949,-95.00395 C 103.76011,408.28671 59.532236,417.0868 30.122564,446.49647 0.712891,475.90615 -8.0871904,520.13402 7.8283485,558.55901 23.74392,596.98407 61.240561,622.03849 102.8323,622.03849 h 25.70807 l 25.70807,-25.70808 -25.70807,-25.70807 H 102.8323" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path91"
+         style="fill:none;stroke:#000000;stroke-linecap:round"
+         d="m 744.09449,596.33041 -25.70808,25.70808" />
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:94.9475px;line-height:1.25;font-family:Comfortaa;-inkscape-font-specification:'Comfortaa, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.98904"
+       x="245.63548"
+       y="719.40308"
+       id="text854"
+       transform="scale(1.0549747,0.94789005)"><tspan
+         sodipodi:role="line"
+         id="tspan852"
+         x="245.63548"
+         y="719.40308"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:94.9475px;font-family:Comfortaa;-inkscape-font-specification:'Comfortaa, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:0.98904">XXXII</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:112.578px;line-height:1.25;font-family:Comfortaa;-inkscape-font-specification:'Comfortaa, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1727"
+       x="84.397324"
+       y="481.74701"
+       id="text854-0"
+       transform="scale(1.1080841,0.9024586)"><tspan
+         sodipodi:role="line"
+         id="tspan880"
+         x="84.397324"
+         y="481.74701"
+         style="stroke-width:1.1727">ESP</tspan></text>
+    <g
+       id="g1215"
+       transform="matrix(1.1776183,0,0,1.1776183,537.25605,592.16513)">
+      <g
+         id="图层_1_1_">
+	<g
+   id="XMLID_17_">
+		<rect
+   id="XMLID_62_"
+   class="st0"
+   width="93.099998"
+   height="93.099998"
+   x="0"
+   y="0"
+   style="fill:none" />
+
+		<path
+   id="XMLID_61_"
+   class="st1"
+   d="m 34.1,65.2 c 0,2.9 -2.4,5.3 -5.3,5.3 -2.9,0 -5.3,-2.4 -5.3,-5.3 0,-2.9 2.4,-5.3 5.3,-5.3 2.9,0.1 5.3,2.4 5.3,5.3"
+   style="fill:#000000" />
+
+		<path
+   id="XMLID_60_"
+   class="st1"
+   d="M 79.9,59.8 C 76.5,35.9 57.6,17 33.7,13.6 c -2.8,1.5 -5.4,3.3 -7.6,5.5 v 5.1 c 23.8,0 43.2,19.4 43.2,43.2 h 5.1 c 2.2,-2.3 4.1,-4.8 5.5,-7.6"
+   style="fill:#000000" />
+
+		<path
+   id="XMLID_59_"
+   class="st1"
+   d="M 83.9,43.8 C 83.9,24.9 68.6,9.6 49.7,9.6 48.5,9.6 47.3,9.7 46.2,9.8 L 45.4,12 c 16.8,5.9 30.1,19.2 36,36 l 2.3,-0.8 c 0.1,-1.1 0.2,-2.2 0.2,-3.4"
+   style="fill:#000000" />
+
+		<path
+   id="XMLID_58_"
+   class="st1"
+   d="M 49.7,69.7 C 50.5,61.2 46.8,53.3 40.4,48.5 37.1,46 33,44.3 28.5,43.8 c -1.2,-0.1 -2,-1.2 -1.9,-2.3 0.1,-1.1 1,-1.9 2.1,-1.9 0.1,0 0.2,0 0.3,0 4.8,0.5 9.3,2.2 13,4.8 8.1,5.6 13,15.2 11.9,25.7 -0.2,1.7 -0.5,3.2 -0.9,4.8 l 6.2,1.7 c 1.8,-0.5 3.6,-1.2 5.3,-2 0.4,-2.4 0.7,-4.8 0.7,-7.3 0,-19.5 -14.5,-35.8 -33.2,-38.6 -2.3,-0.3 -4.5,-0.3 -6.2,0.1 -5.8,1.5 -10,6.7 -10,12.9 0,5.9 3.9,11 9.3,12.7 1,0.3 2.6,0.5 3.3,0.6 v 0 c 5.9,1 10.4,6.1 10.4,12.3 0,2.5 -0.7,4.8 -2,6.7 l 4.3,2.7 c 2.1,0.5 4.2,0.9 6.4,1.1 1,-2.4 1.9,-5.2 2.2,-8.1"
+   style="fill:#000000" />
+
+		<path
+   id="XMLID_57_"
+   class="st1"
+   d="M 50.1,84.4 C 39.2,84.4 29,80.2 21.4,72.5 13.7,64.8 9.5,54.6 9.5,43.8 c 0,-10.9 4.2,-21.1 11.9,-28.7 0.6,-0.6 1.6,-0.6 2.2,0 0.6,0.6 0.6,1.6 0,2.2 -7.1,7.1 -11,16.5 -11,26.6 0,10 3.9,19.5 11,26.6 7.1,7.1 16.5,11 26.6,11 10,0 19.5,-3.9 26.6,-11 0.6,-0.6 1.6,-0.6 2.2,0 0.6,0.6 0.6,1.6 0,2.2 -7.9,7.5 -18.1,11.7 -28.9,11.7"
+   style="fill:#000000" />
+
+	</g>
+
+	<g
+   id="g1183">
+		
+		
+		<g
+   id="g1178">
+			
+			
+			
+			
+		</g>
+
+		
+		
+		
+	</g>
+
+</g>
+      <g
+         id="图层_2">
+</g>
+    </g>
+  </g>
+  <style
+     type="text/css"
+     id="style1159">
+	.st0{fill:#FF3034;}
+	.st1{fill:#FFFEFE;}
+	.st2{fill:#FFFFFF;}
+</style>
+</svg>


### PR DESCRIPTION
A logo, svg format. Pretty simple and boxy, Based off the original GRBL 'paths' logo. XXXII is, of course, 32 in roman numerals.

**TL;DR:** I needed a logo for some Laserweb mods I am doing.
LW has the ability to add predefined machines, and display a markdown-formatted info panel for the firmware on it's about screen. This was actually somewhat broken, as part of fixing that I also added a mechanism to put a firmware logo above the info panel. 

I then created an (initial) grbl-esp32 profile (as well as fixing the vanilla GRBL one). This logo got created as part of that. It is designed to fit into theside panel (hence the 4:3 boxy shape) in the about screen. Feel free to call it Ugly, I'm not a designer :)

![Screenshot from 2021-03-13 03-06-49](https://user-images.githubusercontent.com/4005142/111015500-58f38c80-83a9-11eb-87dc-08d03a09abbd.png)
**TTL;DR** (sorry, this got long)
Demo at: https://easytarget-org.github.io/lw-mods-preview/index.html   (select Settings, chose grbl-esp32 in the machines dropdown, click Apply, click OK, and select the about tab.)

A lot of UI/Options work, more machine-level defaults, split Laser/Mill start codes, fluid control, job time estimates, filename templates with strftime() substitutions. More space for the consol and the webcam finally stays closed when dismissed.

I'm getting ready to PR the main LW project with my mods. But the preview above is fully functional and can produce gcode for saving to disk. Laserweb runs entirely in your browser, it's basically just a vast Javascript. This preview was actually built on a Pi4
- It needs the corresponding updated lw.comm-server for the 'firmware detection' options to take effect or streaming directly to a machine.