### PR TITLE
Pio down rev

### DIFF
--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -22,7 +22,7 @@
 
 // Grbl versioning system
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20210329";
+const char* const GRBL_VERSION_BUILD = "20210401";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,7 +42,7 @@ build_flags =
 [env]
 ;lib_deps = 
 ;	TMCStepper@>=0.7.0,<1.0.0
-platform = espressif32
+platform = espressif32@3.0.0 ; temporary fix for lost uart rx characters
 board = esp32dev
 framework = arduino
 upload_speed = 921600


### PR DESCRIPTION
Temporary fix to lost UART rx characters. Reverts esp framework to 1.0.4



https://github.com/espressif/arduino-esp32/issues/5005 