### PR TITLE
Better homing for the midTbot

### DIFF
--- a/Grbl_Esp32/src/Machines/midtbot.h
+++ b/Grbl_Esp32/src/Machines/midtbot.h
@@ -52,7 +52,6 @@
 #define DEFAULT_HOMING_CYCLE_0      bit(Z_AXIS)
 #define DEFAULT_HOMING_CYCLE_1      bit(Y_AXIS)
 #define DEFAULT_HOMING_CYCLE_2      bit(X_AXIS)
-
 #define DEFAULT_HOMING_DIR_MASK     (bit(X_AXIS) | bit (Z_AXIS)) // these home negative
 
 #define DEFAULT_STEP_PULSE_MICROSECONDS 3
@@ -94,7 +93,5 @@
 #define DEFAULT_X_MAX_TRAVEL 100.0 // mm NOTE: Must be a positive value.
 #define DEFAULT_Y_MAX_TRAVEL 100.0 // mm NOTE: Must be a positive value.
 #define DEFAULT_Z_MAX_TRAVEL 5.0 // This is percent in servo mode
-
-#define DEFAULT_X_HOMING_MPOS DEFAULT_Z_MAX_TRAVEL // stays up after homing
 
 

--- a/Grbl_Esp32/src/Machines/midtbot.h
+++ b/Grbl_Esp32/src/Machines/midtbot.h
@@ -49,9 +49,8 @@
 #define SPINDLE_TYPE SpindleType::NONE
 
 // defaults
-#define DEFAULT_HOMING_CYCLE_0      bit(Z_AXIS)
-#define DEFAULT_HOMING_CYCLE_1      bit(Y_AXIS)
-#define DEFAULT_HOMING_CYCLE_2      bit(X_AXIS)
+#define DEFAULT_HOMING_CYCLE_0      bit(Y_AXIS)
+#define DEFAULT_HOMING_CYCLE_1      bit(X_AXIS)
 #define DEFAULT_HOMING_DIR_MASK     (bit(X_AXIS) | bit (Z_AXIS)) // these home negative
 
 #define DEFAULT_STEP_PULSE_MICROSECONDS 3


### PR DESCRIPTION
Hi Bart.

It's been a while since I've updated the firmware on my lovely midTbot.
I feel that the homing behavior of the current midTbot is a little different from what you intended, so I suggest some changes.

(1) Mpos of X seems to be shifted from its original value when homing.
  It seems to be caused by a typo in midtbot.h.
  It reads as if it was originally intended to PenUp after homing, but that doesn't seem to work in the current implementation.

(2) PenDown occurs when homing.
 In the current implementation, the Z axis is homed first, so it is PenDown (Z is set to 0) first.
 Then, since it is PenDown, it will homing the Y and X axis while drawing with the pen.
 So in the current implementation, I would suggest not homing the Z axis with $H.
 If you must, you can handle it separately with $HZ.

Thank you for your consideration.