### PR TITLE
Fixed bug reporting Gcode comments and user defined macro to the serial interface only

### DIFF
--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -22,7 +22,7 @@
 
 // Grbl versioning system
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20210424";
+const char* const GRBL_VERSION_BUILD = "20210618";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>

--- a/Grbl_Esp32/src/Report.cpp
+++ b/Grbl_Esp32/src/Report.cpp
@@ -801,7 +801,7 @@ void report_gcode_comment(char* comment) {
             index++;
         }
         msg[index - offset] = 0;  // null terminate
-        grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "GCode Comment...%s", msg);
+        grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "GCode Comment...%s", msg);
     }
 }
 

--- a/Grbl_Esp32/src/System.cpp
+++ b/Grbl_Esp32/src/System.cpp
@@ -340,7 +340,7 @@ uint8_t sys_calc_pwm_precision(uint32_t freq) {
 void __attribute__((weak)) user_defined_macro(uint8_t index) {
     // must be in Idle
     if (sys.state != State::Idle) {
-        grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Macro button only permitted in idle");
+        grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "Macro button only permitted in idle");
         return;
     }
 
@@ -364,7 +364,7 @@ void __attribute__((weak)) user_defined_macro(uint8_t index) {
     }
 
     if (user_macro == "") {
-        grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Macro User/Macro%d empty", index);
+        grbl_msg_sendf(CLIENT_ALL, MsgLevel::Info, "Macro User/Macro%d empty", index);
         return;
     }
 


### PR DESCRIPTION
Fixed bug reporting Gcode comments and user defined macro errors to the CLIENT_SERIAL interface only by reporting them to the CLIENT_ALL interface.
#917