### PR TITLE
machine: Add CNC xPRO V5 header

### DIFF
--- a/Grbl_Esp32/Custom/atari_1020.cpp
+++ b/Grbl_Esp32/Custom/atari_1020.cpp
@@ -75,15 +75,12 @@ void machine_init() {
 // this task tracks the Z position and sets the solenoid
 void solenoidSyncTask(void* pvParameters) {
     int32_t          current_position[N_AXIS];  // copy of current location
-    float            m_pos[N_AXIS];             // machine position in mm
     TickType_t       xLastWakeTime;
     const TickType_t xSolenoidFrequency = SOLENOID_TASK_FREQ;   // in ticks (typically ms)
     xLastWakeTime                       = xTaskGetTickCount();  // Initialise the xLastWakeTime variable with the current time.
     while (true) {
         // don't ever return from this or the task dies
-        memcpy(current_position, sys_position, sizeof(sys_position));  // get current position in step
-        system_convert_array_steps_to_mpos(m_pos, current_position);   // convert to millimeters
-        calc_solenoid(m_pos[Z_AXIS]);                                  // calculate kinematics and move the servos
+        calc_solenoid(system_get_mpos()[Z_AXIS]);  // calculate kinematics and move the servos
         vTaskDelayUntil(&xLastWakeTime, xSolenoidFrequency);
     }
 }

--- a/Grbl_Esp32/Custom/custom_code_template.cpp
+++ b/Grbl_Esp32/Custom/custom_code_template.cpp
@@ -24,37 +24,39 @@
 	=======================================================================
 
 This is a template for user-defined C++ code functions.  Grbl can be
-configured to call some optional functions, enabled by #define statements
-in the machine definition .h file.  Implement the functions thus enabled
-herein.  The possible functions are listed and described below.
+configured to call some optional functions. These functions have weak definitions
+in the main code. If you create your own version they will be used instead
 
-To use this file, copy it to a name of your own choosing, and also copy
-Machines/template.h to a similar name.
+Put all of your functions in a .cpp file in the "Custom" folder.
+Add this to your machine definition file
+#define CUSTOM_CODE_FILENAME    "../Custom/YourFile.cpp" 
 
-Example:
-Machines/my_machine.h
-Custom/my_machine.cpp
-
-Edit machine.h to include your Machines/my_machine.h file
-
-Edit Machines/my_machine.h according to the instructions therein.
-
-Fill in the function definitions below for the functions that you have
-enabled with USE_ defines in Machines/my_machine.h
+Be careful to return the correct values
 
 ===============================================================================
 
+Below are all the current weak function
+
 */
 
-#ifdef USE_MACHINE_INIT
 /*
-machine_init() is called when Grbl_ESP32 first starts. You can use it to do any
-special things your machine needs at startup.
+This function is used as a one time setup for your machine.
 */
 void machine_init() {}
-#endif
 
-#ifdef USE_CUSTOM_HOMING
+/*
+This is used to initialize a display.
+*/
+void display_init() {}
+
+/*
+  limitsCheckTravel() is called to check soft limits
+  It returns true if the motion is outside the limit values
+*/
+bool limitsCheckTravel() {
+    return false;
+}
+
 /*
   user_defined_homing(uint8_t cycle_mask) is called at the begining of the normal Grbl_ESP32 homing
   sequence.  If user_defined_homing(uint8_t cycle_mask) returns false, the rest of normal Grbl_ESP32
@@ -66,17 +68,14 @@ bool user_defined_homing(uint8_t cycle_mask) {
     // True = done with homing, false = continue with normal Grbl_ESP32 homing
     return true;
 }
-#endif
 
-#ifdef USE_KINEMATICS
 /*
   Inverse Kinematics converts X,Y,Z cartesian coordinate to the steps
   on your "joint" motors.  It requires the following three functions:
 */
 
 /*
-  inverse_kinematics() looks at incoming move commands and modifies
-  them before Grbl_ESP32 puts them in the motion planner.
+  cartesian_to_motors() converts from cartesian coordinates to motor space.
 
   Grbl_ESP32 processes arcs by converting them into tiny little line segments.
   Kinematics in Grbl_ESP32 works the same way. Search for this function across
@@ -86,9 +85,9 @@ bool user_defined_homing(uint8_t cycle_mask) {
     pl_data = planner data (see the definition of this type to see what it is)
     position = an N_AXIS array of where the machine is starting from for this move
 */
-void inverse_kinematics(float* target, plan_line_data_t* pl_data, float* position) {
+bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {
     // this simply moves to the target. Replace with your kinematics.
-    mc_line(target, pl_data);
+    return mc_line(target, pl_data);
 }
 
 /*
@@ -97,8 +96,7 @@ void inverse_kinematics(float* target, plan_line_data_t* pl_data, float* positio
 
   cycle_mask is a bit mask of the axes being homed this time.
 */
-bool kinematics_pre_homing(uint8_t cycle_mask))
-{
+bool kinematics_pre_homing(uint8_t cycle_mask) {
     return false;  // finish normal homing cycle
 }
 
@@ -106,51 +104,34 @@ bool kinematics_pre_homing(uint8_t cycle_mask))
   kinematics_post_homing() is called at the end of normal homing
 */
 void kinematics_post_homing() {}
-#endif
 
-#ifdef USE_FWD_KINEMATICS
 /*
-  The status command uses forward_kinematics() to convert
+  The status command uses motors_to_cartesian() to convert
   your motor positions to cartesian X,Y,Z... coordinates.
 
   Convert the N_AXIS array of motor positions to cartesian in your code.
 */
-void forward_kinematics(float* position) {
+void motors_to_cartesian(float* cartesian, float* motors, int n_axis) {
     // position[X_AXIS] =
     // position[Y_AXIS] =
 }
-#endif
 
-#ifdef USE_TOOL_CHANGE
 /*
   user_tool_change() is called when tool change gcode is received,
   to perform appropriate actions for your machine.
 */
 void user_tool_change(uint8_t new_tool) {}
-#endif
 
-#if defined(MACRO_BUTTON_0_PIN) || defined(MACRO_BUTTON_1_PIN) || defined(MACRO_BUTTON_2_PIN)
 /*
   options.  user_defined_macro() is called with the button number to
   perform whatever actions you choose.
 */
 void user_defined_macro(uint8_t index) {}
-#endif
 
-#ifdef USE_M30
 /*
   user_m30() is called when an M30 gcode signals the end of a gcode file.
 */
 void user_m30() {}
-#endif
-
-#ifdef USE_MACHINE_TRINAMIC_INIT
-/*
-  machine_triaminic_setup() replaces the normal setup of trinamic
-  drivers with your own code.  For example, you could setup StallGuard
-*/
-void machine_trinamic_setup() {}
-#endif
 
 // If you add any additional functions specific to your machine that
 // require calls from common code, guard their calls in the common code with

--- a/Grbl_Esp32/Custom/mpcnc_laser_module.cpp
+++ b/Grbl_Esp32/Custom/mpcnc_laser_module.cpp
@@ -21,7 +21,6 @@
 	along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef USE_MACHINE_INIT
 /*
 machine_init() is called when Grbl_ESP32 first starts. You can use it to do any
 special things your machine needs at startup.
@@ -32,4 +31,3 @@ void machine_init() {
     pinMode(LVL_SHIFT_ENABLE, OUTPUT);
     digitalWrite(LVL_SHIFT_ENABLE, HIGH);
 }
-#endif

--- a/Grbl_Esp32/Custom/oled_basic.cpp
+++ b/Grbl_Esp32/Custom/oled_basic.cpp
@@ -120,7 +120,6 @@ void draw_checkbox(int16_t x, int16_t y, int16_t width, int16_t height, bool che
 
 void displayDRO() {
     uint8_t oled_y_pos;
-    float   print_position[MAX_N_AXIS];
     //float   wco[MAX_N_AXIS];
 
     display.setTextAlignment(TEXT_ALIGN_LEFT);
@@ -135,10 +134,14 @@ void displayDRO() {
     ControlPins ctrl_pin_state = system_control_get_state();
     bool        prb_pin_state  = probe_get_state();
 
+    display.setTextAlignment(TEXT_ALIGN_RIGHT);
+
+    float* print_position = system_get_mpos();
     if (bit_istrue(status_mask->get(), RtStatus::Position)) {
-        calc_mpos(print_position);
+        display.drawString(60, 14, "M Pos");
     } else {
-        calc_wpos(print_position);
+        display.drawString(60, 14, "W Pos");
+        mpos_to_wpos(print_position);
     }
 
     for (uint8_t axis = X_AXIS; axis < n_axis; axis++) {

--- a/Grbl_Esp32/src/Error.cpp
+++ b/Grbl_Esp32/src/Error.cpp
@@ -80,4 +80,5 @@ std::map<Error, const char*> ErrorNames = {
     { Error::NvsGetStatsFailed, "Failed to get setting status" },
     { Error::AuthenticationFailed, "Authentication failed!" },
     { Error::AnotherInterfaceBusy, "Another interface is busy" },
+    { Error::JogCancelled, "Jog Cancelled" },
 };

--- a/Grbl_Esp32/src/Error.h
+++ b/Grbl_Esp32/src/Error.h
@@ -84,6 +84,7 @@ enum class Error : uint8_t {
     AuthenticationFailed        = 110,
     Eol                         = 111,
     AnotherInterfaceBusy        = 120,
+    JogCancelled                = 130,
 };
 
 extern std::map<Error, const char*> ErrorNames;

--- a/Grbl_Esp32/src/Grbl.cpp
+++ b/Grbl_Esp32/src/Grbl.cpp
@@ -105,6 +105,10 @@ static void reset_variables() {
     plan_sync_position();
     gc_sync_position();
     report_init_message(CLIENT_ALL);
+
+    // used to keep track of a jog command sent to mc_line() so we can cancel it.
+    // this is needed if a jogCancel comes along after we have already parsed a jog and it is in-flight.
+    sys_pl_data_inflight = NULL;
 }
 
 void run_once() {
@@ -118,6 +122,10 @@ void run_once() {
 void __attribute__((weak)) machine_init() {}
 
 void __attribute__((weak)) display_init() {}
+
+void __attribute__((weak)) user_m30() {}
+
+void __attribute__((weak)) user_tool_change(uint8_t new_tool) {}
 /*
   setup() and loop() in the Arduino .ino implements this control flow:
 

--- a/Grbl_Esp32/src/Grbl.h
+++ b/Grbl_Esp32/src/Grbl.h
@@ -22,7 +22,7 @@
 
 // Grbl versioning system
 const char* const GRBL_VERSION       = "1.3a";
-const char* const GRBL_VERSION_BUILD = "20210419";
+const char* const GRBL_VERSION_BUILD = "20210424";
 
 //#include <sdkconfig.h>
 #include <Arduino.h>
@@ -93,27 +93,21 @@ const char* const GRBL_VERSION_BUILD = "20210419";
 void grbl_init();
 void run_once();
 
-void machine_init();  // weak definition in Grbl.cpp
-void display_init();  // weak definition in Grbl.cpp
+void machine_init();                      // weak definition in Grbl.cpp
+void display_init();                      // weak definition in Grbl.cpp
+void user_m30();                          // weak definition in Grbl.cpp/
+void user_tool_change(uint8_t new_tool);  // weak definition in Grbl.cpp
 
 bool user_defined_homing(uint8_t cycle_mask);  // weak definition in Limits.cpp
 
-// Called if USE_KINEMATICS is defined
+// weak definitions in MotionControl.cpp
+bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position);
+bool kinematics_pre_homing(uint8_t cycle_mask);
+void kinematics_post_homing();
 
-void    inverse_kinematics(float* target, plan_line_data_t* pl_data, float* position);
-bool    kinematics_pre_homing(uint8_t cycle_mask);
-void    kinematics_post_homing();
-uint8_t kinematic_limits_check(float* target);
+bool limitsCheckTravel(float* target);  // weak in Limits.cpp; true if out of range
 
-// Called if USE_FWD_KINEMATICS is defined
-void inverse_kinematics(float* position);  // used to return a converted value
-void forward_kinematics(float* position);  // weak definition in Report.cpp
+void motors_to_cartesian(float* cartestian, float* motors, int n_axis);  // weak definition
 
 // Called if MACRO_BUTTON_0_PIN or MACRO_BUTTON_1_PIN or MACRO_BUTTON_2_PIN is defined
 void user_defined_macro(uint8_t index);
-
-// Called if USE_M30 is defined
-void user_m30();
-
-// Called if USE_TOOL_CHANGE is defined
-void user_tool_change(uint8_t new_tool);

--- a/Grbl_Esp32/src/Jog.cpp
+++ b/Grbl_Esp32/src/Jog.cpp
@@ -24,11 +24,13 @@
 #include "Grbl.h"
 
 // Sets up valid jog motion received from g-code parser, checks for soft-limits, and executes the jog.
-Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block) {
+// cancelledInflight will be set to true if was not added to parser due to a cancelJog.
+Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block, bool* cancelledInflight) {
     // Initialize planner data struct for jogging motions.
     // NOTE: Spindle and coolant are allowed to fully function with overrides during a jog.
     pl_data->feed_rate             = gc_block->values.f;
     pl_data->motion.noFeedOverride = 1;
+    pl_data->is_jog                = true;
 #ifdef USE_LINE_NUMBERS
     pl_data->line_number = gc_block->values.n;
 #endif
@@ -37,12 +39,10 @@ Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block) {
             return Error::TravelExceeded;
         }
     }
-// Valid jog command. Plan, set state, and execute.
-#ifndef USE_KINEMATICS
-    mc_line(gc_block->values.xyz, pl_data);
-#else  // else use kinematics
-    inverse_kinematics(gc_block->values.xyz, pl_data, gc_state.position);
-#endif
+    // Valid jog command. Plan, set state, and execute.
+    if (!cartesian_to_motors(gc_block->values.xyz, pl_data, gc_state.position)) {
+        return Error::JogCancelled;
+    }
 
     if (sys.state == State::Idle) {
         if (plan_get_current_block() != NULL) {  // Check if there is a block to execute.

--- a/Grbl_Esp32/src/Jog.h
+++ b/Grbl_Esp32/src/Jog.h
@@ -28,4 +28,5 @@
 const int JOG_LINE_NUMBER = 0;
 
 // Sets up valid jog motion received from g-code parser, checks for soft-limits, and executes the jog.
-Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block);
+// cancelledInflight will be set to true if was not added to parser due to a cancelJog.
+Error jog_execute(plan_line_data_t* pl_data, parser_block_t* gc_block, bool* cancelledInflight);

--- a/Grbl_Esp32/src/Limits.cpp
+++ b/Grbl_Esp32/src/Limits.cpp
@@ -104,7 +104,6 @@ void limits_go_home(uint8_t cycle_mask) {
     // Initialize variables used for homing computations.
     uint8_t n_cycle = (2 * n_homing_locate_cycle + 1);
     uint8_t step_pin[MAX_N_AXIS];
-    float   target[MAX_N_AXIS];
     float   max_travel = 0.0;
 
     auto n_axis = number_axis->get();
@@ -122,7 +121,7 @@ void limits_go_home(uint8_t cycle_mask) {
     uint8_t  n_active_axis;
     AxisMask limit_state, axislock;
     do {
-        system_convert_array_steps_to_mpos(target, sys_position);
+        float* target = system_get_mpos();
         // Initialize and declare variables needed for homing routine.
         axislock      = 0;
         n_active_axis = 0;
@@ -397,7 +396,7 @@ float limitsMinPosition(uint8_t axis) {
 // Checks and reports if target array exceeds machine travel limits.
 // Return true if exceeding limits
 // Set $<axis>/MaxTravel=0 to selectively remove an axis from soft limit checks
-bool limitsCheckTravel(float* target) {
+bool __attribute__((weak)) limitsCheckTravel(float* target) {
     uint8_t idx;
     auto    n_axis = number_axis->get();
     for (idx = 0; idx < n_axis; idx++) {

--- a/Grbl_Esp32/src/Machines/6_pack_TMC2130_XYZ_Test.h
+++ b/Grbl_Esp32/src/Machines/6_pack_TMC2130_XYZ_Test.h
@@ -1,0 +1,110 @@
+#pragma once
+// clang-format off
+
+/*
+    6_pack_TMC2130_XYZ_PWM.h
+
+    Part of Grbl_ESP32
+    Pin assignments for the ESP32 SPI 6-axis board
+    
+    2021-0302 B. Dring for Mike T.
+
+    Grbl_ESP32 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Grbl is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#define MACHINE_NAME            "6 Pack TMC2130 XYZ PWM"
+
+#define N_AXIS 3
+
+// I2S (steppers & other output-only pins)
+#define USE_I2S_OUT
+#define USE_I2S_STEPS
+//#define DEFAULT_STEPPER ST_I2S_STATIC
+
+#define I2S_OUT_BCK      GPIO_NUM_22
+#define I2S_OUT_WS       GPIO_NUM_17
+#define I2S_OUT_DATA     GPIO_NUM_21
+
+#define TRINAMIC_RUN_MODE           Motors::TrinamicMode::CoolStep
+#define TRINAMIC_HOMING_MODE        Motors::TrinamicMode::CoolStep
+
+// Motor Socket #1
+#define X_TRINAMIC_DRIVER       2130
+#define X_DISABLE_PIN           I2SO(0)
+#define X_DIRECTION_PIN         I2SO(1)
+#define X_STEP_PIN              I2SO(2)
+#define X_CS_PIN                I2SO(3)
+#define X_RSENSE                TMC2130_RSENSE_DEFAULT
+
+// Motor Socket #2
+#define Y_TRINAMIC_DRIVER       X_TRINAMIC_DRIVER
+#define Y_DIRECTION_PIN         I2SO(4)
+#define Y_STEP_PIN              I2SO(5)
+#define Y_DISABLE_PIN           I2SO(7)
+#define Y_CS_PIN                I2SO(6)
+#define Y_RSENSE                X_RSENSE
+
+// Motor Socket #3
+#define Z_TRINAMIC_DRIVER       X_TRINAMIC_DRIVER
+#define Z_DISABLE_PIN           I2SO(8)
+#define Z_DIRECTION_PIN         I2SO(9)
+#define Z_STEP_PIN              I2SO(10)
+#define Z_CS_PIN                I2SO(11)
+#define Z_RSENSE                X_RSENSE
+
+
+/*
+    Socket I/O reference
+    The list of modules is here...
+    https://github.com/bdring/6-Pack_CNC_Controller/wiki/CNC-I-O-Module-List
+    Click on each module to get example for using the modules in the sockets
+
+Socket #1
+#1 GPIO_NUM_33 (Sg1)
+#2 GPIO_NUM_32 (Sg2)
+#3 GPIO_NUM_35 (Sg3) (input only)
+#4 GPIO_NUM_34 (Sg4) (input only)
+
+Socket #2
+#1 GPIO_NUM_2
+#2 GPIO_NUM_25
+#3 GPIO_NUM_39 (Sg5) (input only)
+#4 GPIO_NUM_36 (Sg6) (input only)
+
+Socket #3
+#1 GPIO_NUM_26
+#2 GPIO_NUM_4
+#3 GPIO_NUM_16
+#4 GPIO_NUM_27
+
+Socket #4
+#1 GPIO_NUM_14
+#2 GPIO_NUM_13
+#3 GPIO_NUM_15
+#4 GPIO_NUM_12
+
+Socket #5
+#1 I2SO(24)  (output only)
+#2 I2SO(25)  (output only)
+#3 I2SO26)  (output only)
+
+*/
+
+// Socket #1 (Empty)
+// Install StallGuard Jumpers
+#define X_LIMIT_PIN                     GPIO_NUM_33  // Sg1
+#define Y_LIMIT_PIN                     GPIO_NUM_32  // Sg2
+#define Z_LIMIT_PIN                     GPIO_NUM_35  // Sg3
+#define CONTROL_SAFETY_DOOR_PIN    GPIO_NUM_34  // Sg4
+
+
+// === Default settings
+#define DEFAULT_STEP_PULSE_MICROSECONDS I2S_OUT_USEC_PER_PULSE

--- a/Grbl_Esp32/src/Machines/CNC_xPRO_V5_XYYZ_PWM_NO.h
+++ b/Grbl_Esp32/src/Machines/CNC_xPRO_V5_XYYZ_PWM_NO.h
@@ -1,0 +1,154 @@
+#pragma once
+// clang-format off
+
+/*
+    CNC_XPRO_V5_XYYZ.h
+    Part of Grbl_ESP32
+
+    Pin assignments for a 3-axis with Y ganged using Triaminic drivers
+    in daisy-chained SPI mode.
+    https://github.com/bdring/4_Axis_SPI_CNC
+
+    2019    - Bart Dring
+    2020    - Mitch Bradley
+    2020    - Spark Concepts 
+
+    Grbl_ESP32 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Grbl is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define MACHINE_NAME "CNC_xPRO_V5_XYYZ_PWM_NO"
+
+#ifdef N_AXIS
+        #undef N_AXIS
+#endif
+#define N_AXIS 3 // can be 3 or 4. (if 3 install bypass jumper next to the A driver)
+
+#define TRINAMIC_DAISY_CHAIN
+
+#define TRINAMIC_RUN_MODE           TrinamicMode :: CoolStep
+#define TRINAMIC_HOMING_MODE        TrinamicMode :: CoolStep
+
+// Use SPI enable instead of the enable pin
+// The hardware enable pin is tied to ground
+#define USE_TRINAMIC_ENABLE
+
+//#define DEFAULT_HOMING_SQUARED_AXES bit(Y_AXIS)
+
+// Y motor connects to the 1st driver
+#define X_TRINAMIC_DRIVER       5160        // Which Driver Type?
+#define X_RSENSE                0.05f
+#define X_STEP_PIN              GPIO_NUM_12
+#define X_DIRECTION_PIN         GPIO_NUM_14
+#define X_CS_PIN                GPIO_NUM_17  // Daisy Chain, all share same CS pin
+
+// Y motor connects to the 2nd driver
+#define Y_TRINAMIC_DRIVER       5160        // Which Driver Type?
+#define Y_RSENSE                0.05f
+#define Y_STEP_PIN              GPIO_NUM_27
+#define Y_DIRECTION_PIN         GPIO_NUM_26
+#define Y_CS_PIN                X_CS_PIN  // Daisy Chain, all share same CS pin
+
+// Y2 motor connects to the 2nd driver
+#define Y2_TRINAMIC_DRIVER       5160        // Which Driver Type?
+#define Y2_RSENSE                0.05f
+#define Y2_STEP_PIN              GPIO_NUM_33  // Z on schem
+#define Y2_DIRECTION_PIN         GPIO_NUM_32   // Z on schem
+#define Y2_CS_PIN                X_CS_PIN  // Daisy Chain, all share same CS pin
+
+
+// Z Axis motor connects to the 4th driver
+#define Z_TRINAMIC_DRIVER       5160        // Which Driver Type?
+#define Z_RSENSE                0.05f
+#define Z_STEP_PIN              GPIO_NUM_15 // A on schem
+#define Z_DIRECTION_PIN         GPIO_NUM_2 // A on schem
+#define Z_CS_PIN                X_CS_PIN  // Daisy Chain, all share same CS pin
+
+// Mist is a 3.3V output
+// Turn on with M7 and off with M9
+#define COOLANT_MIST_PIN        GPIO_NUM_21
+#define SPINDLE_TYPE            SpindleType::PWM
+#define SPINDLE_OUTPUT_PIN      GPIO_NUM_25
+#define SPINDLE_ENABLE_PIN      GPIO_NUM_4
+#define VFD_RS485_TXD_PIN		GPIO_NUM_4
+#define VFD_RS485_RXD_PIN		GPIO_NUM_25
+
+// Relay operation
+// Install Jumper near relay
+// For spindle Use max RPM of 1
+// For PWM remove jumper and set MAX RPM to something higher ($30 setting)
+// Interlock jumper along top edge needs to be installed for both versions
+#define DEFAULT_SPINDLE_RPM_MAX     12000 // Should be 1 for relay operation
+
+#define PROBE_PIN               GPIO_NUM_22
+//#define SHOW_EXTENDED_SETTINGS
+#define X_LIMIT_PIN             GPIO_NUM_35
+//#define A_LIMIT_PIN           GPIO_NUM_36
+#define Y_LIMIT_PIN             GPIO_NUM_34
+#define Z_LIMIT_PIN             GPIO_NUM_39
+#define CONTROL_SAFETY_DOOR_PIN GPIO_NUM_16
+
+
+// Define default configuration
+ //steps per mm
+ #define DEFAULT_X_STEPS_PER_MM 200.0
+ #define DEFAULT_Y_STEPS_PER_MM 200.0
+ #define DEFAULT_Z_STEPS_PER_MM 200.0
+ #define DEFAULT_A_STEPS_PER_MM 200.0
+
+ //max speed
+ #    define DEFAULT_X_MAX_RATE 2500.0 
+ #    define DEFAULT_Y_MAX_RATE 2500.0 
+ #    define DEFAULT_Z_MAX_RATE 2500.0 
+ 
+ #    define DEFAULT_X_ACCELERATION 100.0
+ #    define DEFAULT_Y_ACCELERATION 100.0
+ #    define DEFAULT_Z_ACCELERATION 100.0
+ 
+ //default motor run current
+ #    define DEFAULT_X_CURRENT 1.8
+ #    define DEFAULT_Y_CURRENT 1.8
+ #    define DEFAULT_Z_CURRENT 1.8
+ #    define DEFAULT_A_CURRENT 1.8
+ 
+ //default motor hold current
+ #    define DEFAULT_X_HOLD_CURRENT 1.25 
+ #    define DEFAULT_Y_HOLD_CURRENT 1.25 
+ #    define DEFAULT_Z_HOLD_CURRENT 1.25 
+ #    define DEFAULT_A_HOLD_CURRENT 1.25 
+ 
+ //micro steps
+ #    define DEFAULT_X_MICROSTEPS 8
+ #    define DEFAULT_Y_MICROSTEPS 8
+ #    define DEFAULT_Z_MICROSTEPS 8
+ 
+ //homing cycles (z then xy combined)
+ #    define DEFAULT_HOMING_CYCLE_0 bit(Z_AXIS)
+ #    define DEFAULT_HOMING_CYCLE_1 (bit(X_AXIS) | bit(Y_AXIS))
+ #    define DEFAULT_HOMING_PULLOFF 2.5
+ 
+ //Stepper settings
+ #    define DEFAULT_STEP_PULSE_MICROSECONDS 4
+ #    define DEFAULT_STEPPER_IDLE_LOCK_TIME 255 
+ 
+ //switchs and probes
+ #    define DEFAULT_INVERT_PROBE_PIN 1
+ #    define DEFAULT_INVERT_LIMIT_PINS 1
+ 
+ // Macro3 | Macro2 | Macro 1| Macr0 |Cycle Start | Feed Hold | Reset | Safety Door
+ // For example B1101 will invert the function of the Reset pin.
+ #ifdef INVERT_CONTROL_PIN_MASK
+	#undef INVERT_CONTROL_PIN_MASK
+ #endif
+ // NC Door = B00001110, NO Door = B00001111
+ #	  define INVERT_CONTROL_PIN_MASK B00001111

--- a/Grbl_Esp32/src/Machines/atari_1020.h
+++ b/Grbl_Esp32/src/Machines/atari_1020.h
@@ -140,11 +140,7 @@
 #define ATARI_HOMING_ATTEMPTS 13
 
 // tells grbl we have some special functions to call
-#define USE_MACHINE_INIT
-#define USE_CUSTOM_HOMING
-#define USE_TOOL_CHANGE
 #define ATARI_TOOL_CHANGE_Z 5.0
-#define USE_M30 // use the user defined end of program
 
 #ifndef atari_h
     #define atari_h

--- a/Grbl_Esp32/src/Machines/fysetc_ant.h
+++ b/Grbl_Esp32/src/Machines/fysetc_ant.h
@@ -1,0 +1,85 @@
+#pragma once
+// clang-format off
+
+/*
+    fysetc_ant.h
+    https://github.com/FYSETC/FYSETC-E4
+
+    2020-12-03 B. Dring
+
+    This is a machine definition file to use the FYSETC E4 3D Printer controller
+    This is a 4 motor controller. This is setup for XYZA, but XYYZ, could also be used.
+    There are 5 inputs
+    The controller has outputs for a Fan, Hotbed and Extruder. There are mapped to
+    spindle, mist and flood coolant to drive an external relay.
+
+    Grbl_ESP32 is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Grbl is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define MACHINE_NAME            "FYSETC E4 3D Printer Controller"
+
+#define N_AXIS 4
+
+#define CUSTOM_CODE_FILENAME    "../Custom/CoreXY.cpp"
+
+#define USE_KINEMATICS      // there are kinematic equations for this machine
+
+#define TRINAMIC_RUN_MODE       TrinamicMode :: StealthChop
+#define TRINAMIC_HOMING_MODE    TrinamicMode :: StealthChop
+
+#define TMC_UART                UART_NUM_1
+#define TMC_UART_RX             GPIO_NUM_21
+#define TMC_UART_TX             GPIO_NUM_22   
+
+#define X_TRINAMIC_DRIVER       2209
+#define X_STEP_PIN              GPIO_NUM_27
+#define X_DIRECTION_PIN         GPIO_NUM_26
+#define X_RSENSE                TMC2209_RSENSE_DEFAULT
+#define X_DRIVER_ADDRESS        1
+#define DEFAULT_X_MICROSTEPS    16
+
+#define Y_TRINAMIC_DRIVER       2209
+#define Y_STEP_PIN              GPIO_NUM_33
+#define Y_DIRECTION_PIN         GPIO_NUM_32
+#define Y_RSENSE                TMC2209_RSENSE_DEFAULT
+#define Y_DRIVER_ADDRESS        3
+#define DEFAULT_Y_MICROSTEPS    16
+
+#define Z_TRINAMIC_DRIVER       2209
+#define Z_STEP_PIN              GPIO_NUM_14
+#define Z_DIRECTION_PIN         GPIO_NUM_12
+#define Z_RSENSE                TMC2209_RSENSE_DEFAULT
+#define Z_DRIVER_ADDRESS        0
+#define DEFAULT_Z_MICROSTEPS    16
+
+#define A_TRINAMIC_DRIVER       2209
+#define A_STEP_PIN              GPIO_NUM_16
+#define A_DIRECTION_PIN         GPIO_NUM_17
+#define A_RSENSE                TMC2209_RSENSE_DEFAULT
+#define A_DRIVER_ADDRESS        2
+#define DEFAULT_A_MICROSTEPS    16
+
+#define X_LIMIT_PIN             GPIO_NUM_34
+#define Y_LIMIT_PIN             GPIO_NUM_35
+#define Z_LIMIT_PIN             GPIO_NUM_15
+#define A_LIMIT_PIN             GPIO_NUM_36   // Labeled TB
+#define PROBE_PIN               GPIO_NUM_39  // Labeled TE
+
+// OK to comment out to use pin for other features
+#define STEPPERS_DISABLE_PIN    GPIO_NUM_25
+
+#define SPINDLE_TYPE            SpindleType::RELAY
+#define SPINDLE_OUTPUT_PIN      GPIO_NUM_13  // labeled Fan
+#define COOLANT_MIST_PIN        GPIO_NUM_2   // Labeled Hotbed
+#define COOLANT_FLOOD_PIN       GPIO_NUM_4   // Labeled Heater

--- a/Grbl_Esp32/src/Machines/fysetc_e4.h
+++ b/Grbl_Esp32/src/Machines/fysetc_e4.h
@@ -2,12 +2,12 @@
 // clang-format off
 
 /*
-    fystec_e4.h
+    fysetc_e4.h
     https://github.com/FYSETC/FYSETC-E4
 
     2020-12-03 B. Dring
 
-    This is a machine definition file to use the FYSTEC E4 3D Printer controller
+    This is a machine definition file to use the FYSETC E4 3D Printer controller
     This is a 4 motor controller. This is setup for XYZA, but XYYZ, could also be used.
     There are 5 inputs
     The controller has outputs for a Fan, Hotbed and Extruder. There are mapped to
@@ -27,7 +27,7 @@
     along with Grbl_ESP32.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define MACHINE_NAME            "FYSTEC E4 3D Printer Controller"
+#define MACHINE_NAME            "FYSETC E4 3D Printer Controller"
 
 #define N_AXIS 4
 

--- a/Grbl_Esp32/src/Machines/midtbot_x2.h
+++ b/Grbl_Esp32/src/Machines/midtbot_x2.h
@@ -27,28 +27,47 @@
 
 #define MACHINE_NAME "midTbot"
 
+#define DISPLAY_CODE_FILENAME   "Custom/oled_basic.cpp"
+
 #define CUSTOM_CODE_FILENAME    "../Custom/CoreXY.cpp"
-
-#define MIDTBOT         // applies the midTbot geometry correction to the CoreXY kinematics 
-
+#define MIDTBOT             // applies the geometry correction to the kinematics 
+#define USE_KINEMATICS      // there are kinematic equations for this machine
+#define USE_FWD_KINEMATICS  // report in cartesian
 #define SPINDLE_TYPE    SpindleType::NONE
 
-#define X_STEP_PIN      GPIO_NUM_12
-#define Y_STEP_PIN      GPIO_NUM_14
+#define TRINAMIC_UART_RUN_MODE       TrinamicUartMode :: StealthChop
+#define TRINAMIC_UART_HOMING_MODE    TrinamicUartMode :: StealthChop
 
-#define X_DIRECTION_PIN GPIO_NUM_26
-#define Y_DIRECTION_PIN GPIO_NUM_25
+#define TMC_UART                UART_NUM_1
+#define TMC_UART_RX             GPIO_NUM_21
+#define TMC_UART_TX             GPIO_NUM_22   
 
-#define STEPPERS_DISABLE_PIN GPIO_NUM_13
+#define X_TRINAMIC_DRIVER       2209
+#define X_STEP_PIN              GPIO_NUM_25 //GPIO_NUM_32
+#define X_DIRECTION_PIN         GPIO_NUM_33 // GPIO_NUM_26
+#define X_RSENSE                TMC2209_RSENSE_DEFAULT
+#define X_DRIVER_ADDRESS        1
+#define DEFAULT_X_MICROSTEPS    16
 
-#define X_LIMIT_PIN     GPIO_NUM_2
-#define Y_LIMIT_PIN     GPIO_NUM_4
+#define Y_TRINAMIC_DRIVER       2209
+#define Y_STEP_PIN              GPIO_NUM_32 //GPIO_NUM_25
+#define Y_DIRECTION_PIN         GPIO_NUM_26 //GPIO_NUM_33
+#define Y_RSENSE                TMC2209_RSENSE_DEFAULT
+#define Y_DRIVER_ADDRESS        0
+#define DEFAULT_Y_MICROSTEPS    16
 
-#define Z_SERVO_PIN             GPIO_NUM_27
+#define STEPPERS_DISABLE_PIN GPIO_NUM_27
+
+#define X_LIMIT_PIN     GPIO_NUM_4
+#define Y_LIMIT_PIN     GPIO_NUM_12
+
+#define Z_SERVO_PIN             GPIO_NUM_15
+
+// Set $Homing/Cycle0=Y and $Homing/Cycle1=X
 
 #define SPINDLE_TYPE SpindleType::NONE
 
-// defaults
+// ==================   defaults ================================
 #define DEFAULT_HOMING_CYCLE_0      bit(Z_AXIS)
 #define DEFAULT_HOMING_CYCLE_1      bit(Y_AXIS)
 #define DEFAULT_HOMING_CYCLE_2      bit(X_AXIS)
@@ -61,7 +80,7 @@
 #define DEFAULT_STEPPING_INVERT_MASK    0 // uint8_t
 #define DEFAULT_DIRECTION_INVERT_MASK   2 // uint8_t
 #define DEFAULT_INVERT_ST_ENABLE        0 // boolean
-#define DEFAULT_INVERT_LIMIT_PINS       1 // boolean
+#define DEFAULT_INVERT_LIMIT_PINS       0 // boolean
 #define DEFAULT_INVERT_PROBE_PIN        0 // boolean
 
 #define DEFAULT_STATUS_REPORT_MASK 1

--- a/Grbl_Esp32/src/Machines/mpcnc_laser_module_v1p2.h
+++ b/Grbl_Esp32/src/Machines/mpcnc_laser_module_v1p2.h
@@ -30,7 +30,6 @@
 #define MACHINE_NAME "MPCNC_V1P2 with Laser Module"
 
 // The laser module fires without a low signal. This keeps the enable on
-#define USE_MACHINE_INIT
 #define LVL_SHIFT_ENABLE        GPIO_NUM_32
 #define CUSTOM_CODE_FILENAME    "Custom/mpcnc_laser_module.cpp"
 

--- a/Grbl_Esp32/src/Machines/polar_coaster.h
+++ b/Grbl_Esp32/src/Machines/polar_coaster.h
@@ -37,9 +37,6 @@
 #define POLAR_AXIS 1
 
 #define SEGMENT_LENGTH 0.5 // segment length in mm
-#define USE_KINEMATICS
-#define USE_FWD_KINEMATICS // report in cartesian
-#define USE_M30
 
 #define X_STEP_PIN              GPIO_NUM_15
 #define Y_STEP_PIN              GPIO_NUM_2
@@ -123,4 +120,6 @@
 
 #define DEFAULT_X_MAX_TRAVEL 50.0 // mm NOTE: Must be a positive value.
 #define DEFAULT_Y_MAX_TRAVEL 300.0 // mm NOTE: Must be a positive value.
-#define DEFAULT_Z_MAX_TRAVEL 100.0 // This is percent in servo mode
+#define DEFAULT_Z_MAX_TRAVEL 5.0 // This is percent in servo mode
+
+#define DEFAULT_Z_HOMING_MPOS DEFAULT_Z_MAX_TRAVEL // stays up after homing

--- a/Grbl_Esp32/src/Machines/tapster_3.h
+++ b/Grbl_Esp32/src/Machines/tapster_3.h
@@ -23,12 +23,6 @@
 
 #define N_AXIS 3
 
-// ================= Firmware Customization ===================
-
-#define USE_KINEMATICS				// there are kinematic equations for this machine
-#define USE_FWD_KINEMATICS          // report in cartesian
-#define USE_MACHINE_INIT			// There is some custom initialization for this machine
-	
 // ================== Delta Geometry ===========================
 
 #define RADIUS_FIXED                70.0   // radius of the fixed side (length of motor cranks)

--- a/Grbl_Esp32/src/Machines/tapster_pro_6P_trinamic.h
+++ b/Grbl_Esp32/src/Machines/tapster_pro_6P_trinamic.h
@@ -26,8 +26,6 @@
 #define FWD_KINEMATICS_REPORTING   // report in cartesian
 #define USE_RMT_STEPS              // Use the RMT periferal to generate step pulses
 #define USE_TRINAMIC               // some Trinamic motors are used on this machine
-#define USE_MACHINE_TRINAMIC_INIT  // there is a machine specific setup for the drivers
-#define USE_MACHINE_INIT           // There is some custom initialization for this machine
 
 #define SEGMENT_LENGTH 0.5  // segment length in mm
 #define KIN_ANGLE_CALC_OK 0
@@ -40,10 +38,6 @@
 */
 
 #define N_AXIS 3
-
-#define USE_KINEMATICS      // there are kinematic equations for this machine
-#define USE_FWD_KINEMATICS  // report in cartesian
-#define USE_MACHINE_INIT    // There is some custom initialization for this machine
 
 // ================== Delta Geometry ===========================
 

--- a/Grbl_Esp32/src/MotionControl.cpp
+++ b/Grbl_Esp32/src/MotionControl.cpp
@@ -33,15 +33,6 @@
 
 SquaringMode ganged_mode = SquaringMode::Dual;
 
-// this allows kinematics to be used.
-void mc_line_kins(float* target, plan_line_data_t* pl_data, float* position) {
-#ifndef USE_KINEMATICS
-    mc_line(target, pl_data);
-#else  // else use kinematics
-    inverse_kinematics(target, pl_data, position);
-#endif
-}
-
 // Execute linear motion in absolute millimeter coordinates. Feed rate given in millimeters/second
 // unless invert_feed_rate is true. Then the feed_rate means that the motion should be completed in
 // (1 minute)/feed_rate time.
@@ -49,7 +40,11 @@ void mc_line_kins(float* target, plan_line_data_t* pl_data, float* position) {
 // segments, must pass through this routine before being passed to the planner. The seperation of
 // mc_line and plan_buffer_line is done primarily to place non-planner-type functions from being
 // in the planner and to let backlash compensation or canned cycle integration simple and direct.
-void mc_line(float* target, plan_line_data_t* pl_data) {
+// returns true if line was submitted to planner, or false if intentionally dropped.
+bool mc_line(float* target, plan_line_data_t* pl_data) {
+    bool submitted_result = false;
+    // store the plan data so it can be cancelled by the protocol system if needed
+    sys_pl_data_inflight = pl_data;
     // If enabled, check for soft limit violations. Placed here all line motions are picked up
     // from everywhere in Grbl.
     if (soft_limits->get()) {
@@ -60,7 +55,8 @@ void mc_line(float* target, plan_line_data_t* pl_data) {
     }
     // If in check gcode mode, prevent motion by blocking planner. Soft limits still work.
     if (sys.state == State::CheckMode) {
-        return;
+        sys_pl_data_inflight = NULL;
+        return submitted_result;
     }
     // NOTE: Backlash compensation may be installed here. It will need direction info to track when
     // to insert a backlash line motion(s) before the intended line motion and will require its own
@@ -80,7 +76,8 @@ void mc_line(float* target, plan_line_data_t* pl_data) {
     do {
         protocol_execute_realtime();  // Check for any run-time commands
         if (sys.abort) {
-            return;  // Bail, if system abort.
+            sys_pl_data_inflight = NULL;
+            return submitted_result;  // Bail, if system abort.
         }
         if (plan_check_full_buffer()) {
             protocol_auto_cycle_start();  // Auto-cycle start when buffer is full.
@@ -90,9 +87,29 @@ void mc_line(float* target, plan_line_data_t* pl_data) {
     } while (1);
     // Plan and queue motion into planner buffer
     // uint8_t plan_status; // Not used in normal operation.
-    plan_buffer_line(target, pl_data);
+    if (sys_pl_data_inflight == pl_data) {
+        plan_buffer_line(target, pl_data);
+        submitted_result = true;
+    }
+    sys_pl_data_inflight = NULL;
+    return submitted_result;
 }
 
+bool __attribute__((weak)) cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position) {
+    return mc_line(target, pl_data);
+}
+
+bool __attribute__((weak)) kinematics_pre_homing(uint8_t cycle_mask) {
+    return false;  // finish normal homing cycle
+}
+
+void __attribute__((weak)) kinematics_post_homing() {}
+
+void __attribute__((weak)) motors_to_cartesian(float* cartesian, float* motors, int n_axis) {
+    memcpy(cartesian, motors, n_axis * sizeof(motors[0]));
+}
+
+void __attribute__((weak)) forward_kinematics(float* position) {}
 // Execute an arc in offset mode format. position == current xyz, target == target xyz,
 // offset == offset from current xyz, axis_X defines circle plane in tool space, axis_linear is
 // the direction of helical travel, radius == circle radius, isclockwise boolean. Used
@@ -117,14 +134,12 @@ void mc_arc(float*            target,
     float rt_axis1     = target[axis_1] - center_axis1;
 
     float previous_position[MAX_N_AXIS] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-#ifdef USE_KINEMATICS
 
     uint16_t n;
     auto     n_axis = number_axis->get();
     for (n = 0; n < n_axis; n++) {
         previous_position[n] = position[n];
     }
-#endif
     // CCW angle between position and target from circle center. Only one atan2() trig computation required.
     float angular_travel = atan2(r_axis0 * rt_axis1 - r_axis1 * rt_axis0, r_axis0 * rt_axis0 + r_axis1 * rt_axis1);
     if (is_clockwise_arc) {  // Correct atan2 output per direction
@@ -206,15 +221,11 @@ void mc_arc(float*            target,
             position[axis_0] = center_axis0 + r_axis0;
             position[axis_1] = center_axis1 + r_axis1;
             position[axis_linear] += linear_per_segment;
-#ifdef USE_KINEMATICS
             pl_data->feed_rate = original_feedrate;  // This restores the feedrate kinematics may have altered
-            mc_line_kins(position, pl_data, previous_position);
+            cartesian_to_motors(position, pl_data, previous_position);
             previous_position[axis_0]      = position[axis_0];
             previous_position[axis_1]      = position[axis_1];
             previous_position[axis_linear] = position[axis_linear];
-#else
-            mc_line(position, pl_data);
-#endif
             // Bail mid-circle on system abort. Runtime command check already performed by mc_line.
             if (sys.abort) {
                 return;
@@ -222,7 +233,7 @@ void mc_arc(float*            target,
         }
     }
     // Ensure last segment arrives at target location.
-    mc_line_kins(target, pl_data, previous_position);
+    cartesian_to_motors(target, pl_data, previous_position);
 }
 
 // Execute dwell in seconds.
@@ -292,11 +303,9 @@ void mc_homing_cycle(uint8_t cycle_mask) {
 
     // This give kinematics a chance to do something before normal homing
     // if it returns true, the homing is canceled.
-#ifdef USE_KINEMATICS
     if (kinematics_pre_homing(cycle_mask)) {
         return;
     }
-#endif
     // Check and abort homing cycle, if hard limits are already enabled. Helps prevent problems
     // with machines with limits wired on both ends of travel to one limit pin.
     // TODO: Move the pin-specific LIMIT_PIN call to Limits.cpp as a function.
@@ -366,10 +375,8 @@ void mc_homing_cycle(uint8_t cycle_mask) {
     // Sync gcode parser and planner positions to homed position.
     gc_sync_position();
     plan_sync_position();
-#ifdef USE_KINEMATICS
     // This give kinematics a chance to do something after normal homing
     kinematics_post_homing();
-#endif
     // If hard limits feature enabled, re-enable hard limits pin change register after homing cycle.
     limits_init();
 }
@@ -412,7 +419,7 @@ GCUpdatePos mc_probe_cycle(float* target, plan_line_data_t* pl_data, uint8_t par
     }
     // Setup and queue probing motion. Auto cycle-start should not start the cycle.
     grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Found");
-    mc_line_kins(target, pl_data, gc_state.position);
+    cartesian_to_motors(target, pl_data, gc_state.position);
     // Activate the probing state monitor in the stepper module.
     sys_probe_state = Probe::Active;
     // Perform probing cycle. Wait here until probe is triggered or motion completes.

--- a/Grbl_Esp32/src/MotionControl.h
+++ b/Grbl_Esp32/src/MotionControl.h
@@ -35,8 +35,8 @@ const int PARKING_MOTION_LINE_NUMBER = 0;
 // Execute linear motion in absolute millimeter coordinates. Feed rate given in millimeters/second
 // unless invert_feed_rate is true. Then the feed_rate means that the motion should be completed in
 // (1 minute)/feed_rate time.
-void mc_line_kins(float* target, plan_line_data_t* pl_data, float* position);
-void mc_line(float* target, plan_line_data_t* pl_data);
+bool cartesian_to_motors(float* target, plan_line_data_t* pl_data, float* position);
+bool mc_line(float* target, plan_line_data_t* pl_data);  // returns true if line was submitted to planner
 
 // Execute an arc in offset mode format. position == current xyz, target == target xyz,
 // offset == offset from current xyz, axis_XXX defines circle plane in tool space, axis_linear is

--- a/Grbl_Esp32/src/Motors/Dynamixel2.cpp
+++ b/Grbl_Esp32/src/Motors/Dynamixel2.cpp
@@ -36,7 +36,7 @@ namespace Motors {
             grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "Dynamixel Error. Missing pin definitions");
             _has_errors = true;
         } else {
-            _has_errors = false;   // The motor can be used
+            _has_errors = false;  // The motor can be used
         }
     }
 
@@ -103,8 +103,8 @@ namespace Motors {
             }
 
         } else {
-            grbl_msg_sendf(CLIENT_SERIAL, MsgLevel::Info, "%s Dynamixel Servo ID %d Ping failed", reportAxisNameMsg(_axis_index, _dual_axis_index),
-_id);
+            grbl_msg_sendf(
+                CLIENT_SERIAL, MsgLevel::Info, "%s Dynamixel Servo ID %d Ping failed", reportAxisNameMsg(_axis_index, _dual_axis_index), _id);
             return false;
         }
 
@@ -197,7 +197,7 @@ _id);
 
         set_disable(false);
         set_location();  // force the PWM to update now
-        return false;  // Cannot do conventional homing
+        return false;    // Cannot do conventional homing
     }
 
     void Dynamixel2::dxl_goal_position(int32_t position) {
@@ -345,15 +345,13 @@ _id);
         tx_message[++msg_index] = 4;                                  // low order data length
         tx_message[++msg_index] = 0;                                  // high order data length
 
-        auto n_axis = number_axis->get();
+        auto   n_axis = number_axis->get();
+        float* mpos   = system_get_mpos();
         for (uint8_t axis = X_AXIS; axis < n_axis; axis++) {
             for (uint8_t gang_index = 0; gang_index < 2; gang_index++) {
                 current_id = ids[axis][gang_index];
                 if (current_id != 0) {
                     count++;  // keep track of the count for the message length
-
-                    //determine the location of the axis
-                    float target = system_convert_axis_steps_to_mpos(sys_position, axis);  // get the axis machine position in mm
 
                     dxl_count_min = DXL_COUNT_MIN;
                     dxl_count_max = DXL_COUNT_MAX;
@@ -362,7 +360,8 @@ _id);
                         swap(dxl_count_min, dxl_count_max);
 
                     // map the mm range to the servo range
-                    dxl_position = (uint32_t)mapConstrain(target, limitsMinPosition(axis), limitsMaxPosition(axis), dxl_count_min, dxl_count_max);
+                    dxl_position =
+                        (uint32_t)mapConstrain(mpos[axis], limitsMinPosition(axis), limitsMaxPosition(axis), dxl_count_min, dxl_count_max);
 
                     tx_message[++msg_index] = current_id;                         // ID of the servo
                     tx_message[++msg_index] = dxl_position & 0xFF;                // data

--- a/Grbl_Esp32/src/Motors/Motor.cpp
+++ b/Grbl_Esp32/src/Motors/Motor.cpp
@@ -16,7 +16,6 @@
         Make sure public/private/protected is cleaned up.
         Only a few Unipolar axes have been setup in init()
         Get rid of Z_SERVO, just reply on Z_SERVO_PIN
-        Deal with custom machine ... machine_trinamic_setup();
         Class is ready to deal with non SPI pins, but they have not been needed yet.
             It would be nice in the config message though
     Testing
@@ -34,8 +33,7 @@
 #include "Motor.h"
 
 namespace Motors {
-    Motor::Motor(uint8_t axis_index) :
-        _axis_index(axis_index % MAX_AXES), _dual_axis_index(axis_index / MAX_AXES) {}
+    Motor::Motor(uint8_t axis_index) : _axis_index(axis_index % MAX_AXES), _dual_axis_index(axis_index / MAX_AXES) {}
 
     void Motor::debug_message() {}
 

--- a/Grbl_Esp32/src/Motors/Motors.cpp
+++ b/Grbl_Esp32/src/Motors/Motors.cpp
@@ -16,7 +16,6 @@
 		Make sure public/private/protected is cleaned up.
 		Only a few Unipolar axes have been setup in init()
 		Get rid of Z_SERVO, just reply on Z_SERVO_PIN
-		Deal with custom machine ... machine_trinamic_setup();
 		Class is ready to deal with non SPI pins, but they have not been needed yet.
 			It would be nice in the config message though
 	Testing

--- a/Grbl_Esp32/src/Planner.h
+++ b/Grbl_Esp32/src/Planner.h
@@ -91,6 +91,7 @@ typedef struct {
 #ifdef USE_LINE_NUMBERS
     int32_t line_number;  // Desired line number to report when executing.
 #endif
+    bool         is_jog;         // true if this was generated due to a jog command
 } plan_line_data_t;
 
 // Initialize and reset the motion plan subsystem

--- a/Grbl_Esp32/src/Report.h
+++ b/Grbl_Esp32/src/Report.h
@@ -92,9 +92,6 @@ void report_grbl_settings(uint8_t client, uint8_t show_extended);
 // Prints an echo of the pre-parsed line received right before execution.
 void report_echo_line_received(char* line, uint8_t client);
 
-// calculate the postion for status reports
-void report_calc_status_position(float* print_position, float* wco, bool wpos);
-
 // Prints realtime status report
 void report_realtime_status(uint8_t client);
 
@@ -134,5 +131,4 @@ void reportTaskStackSize(UBaseType_t& saved);
 
 char*  report_state_text();
 float* get_wco();
-void   calc_mpos(float* print_position);
-void   calc_wpos(float* print_position);
+void   mpos_to_wpos(float* position);

--- a/Grbl_Esp32/src/System.cpp
+++ b/Grbl_Esp32/src/System.cpp
@@ -30,6 +30,7 @@ volatile ExecState     sys_rt_exec_state;  // Global realtime executor bitflag v
 volatile ExecAlarm     sys_rt_exec_alarm;  // Global realtime executor bitflag variable for setting various alarms.
 volatile ExecAccessory sys_rt_exec_accessory_override;  // Global realtime executor bitflag variable for spindle/coolant overrides.
 volatile bool          cycle_stop;                      // For state transitions, instead of bitflag
+volatile void*         sys_pl_data_inflight;  // holds a plan_line_data_t while cartesian_to_motors has taken ownership of a line motion
 #ifdef DEBUG
 volatile bool sys_rt_exec_debug;
 #endif
@@ -166,9 +167,6 @@ void system_flag_wco_change() {
     sys.report_wco_counter = 0;
 }
 
-// Returns machine position of axis 'idx'. Must be sent a 'step' array.
-// NOTE: If motor steps and machine position are not in the same coordinate frame, this function
-//   serves as a central place to compute the transformation.
 float system_convert_axis_steps_to_mpos(int32_t* steps, uint8_t idx) {
     float pos;
     float steps_per_mm = axis_settings[idx]->steps_per_mm->get();
@@ -176,14 +174,22 @@ float system_convert_axis_steps_to_mpos(int32_t* steps, uint8_t idx) {
     return pos;
 }
 
+// Returns machine position of axis 'idx'. Must be sent a 'step' array.
+// NOTE: If motor steps and machine position are not in the same coordinate frame, this function
+//   serves as a central place to compute the transformation.
 void system_convert_array_steps_to_mpos(float* position, int32_t* steps) {
-    uint8_t idx;
-    auto    n_axis = number_axis->get();
-    for (idx = 0; idx < n_axis; idx++) {
-        position[idx] = system_convert_axis_steps_to_mpos(steps, idx);
+    auto  n_axis = number_axis->get();
+    float motors[n_axis];
+    for (int idx = 0; idx < n_axis; idx++) {
+        motors[idx] = (float)steps[idx] / axis_settings[idx]->steps_per_mm->get();
     }
-    return;
+    motors_to_cartesian(position, motors, n_axis);
 }
+float* system_get_mpos() {
+    static float position[MAX_N_AXIS];
+    system_convert_array_steps_to_mpos(position, sys_position);
+    return position;
+};
 
 // Returns control pin state as a uint8 bitfield. Each bit indicates the input pin state, where
 // triggered is 1 and not triggered is 0. Invert mask is applied. Bitfield organization is

--- a/Grbl_Esp32/src/System.h
+++ b/Grbl_Esp32/src/System.h
@@ -138,6 +138,7 @@ extern volatile Percent       sys_rt_f_override;               // Feed override 
 extern volatile Percent       sys_rt_r_override;               // Rapid feed override value in percent
 extern volatile Percent       sys_rt_s_override;               // Spindle override value in percent
 extern volatile bool          cycle_stop;
+extern volatile void* sys_pl_data_inflight;  // holds a plan_line_data_t while cartesian_to_motors has taken ownership of a line motion
 #ifdef DEBUG
 extern volatile bool sys_rt_exec_debug;
 #endif
@@ -164,7 +165,8 @@ void  system_flag_wco_change();
 float system_convert_axis_steps_to_mpos(int32_t* steps, uint8_t idx);
 
 // Updates a machine 'position' array based on the 'step' array sent.
-void system_convert_array_steps_to_mpos(float* position, int32_t* steps);
+void   system_convert_array_steps_to_mpos(float* position, int32_t* steps);
+float* system_get_mpos();
 
 // A task that runs after a control switch interrupt for debouncing.
 void controlCheckTask(void* pvParameters);


### PR DESCRIPTION
The Grbl_Esp32 sources modified by Spark Concepts contain a useful
machine definition for the CNC xPRO V5 hardware.

A number of users have been requesting access to the source code for the
device as a git repository ([Spark-Concepts/xPro-V5#8](source-issue)).
After some basic analysis it became clear that the zip file currently
being provided by Spark Concepts contains the following changes based on
commit eaffb964f7:

- Bluetooth: Change `DEFAULT_BT_NAME` from `btgrblesp` to `CNC_xPRO_v5`
- Wifi: Change `DEFAULT_HOSTNAME` from `grblesp` to `CNC_xPRO_V5`
- Wifi: Change SSIDs (STA & AP) from `GRBL_ESP` to `CNC_xPRO_V5`
- Machine: Add machine definitions for the CNC xPRO V5 hardware
- Machine: Change the default machine type from `test_drive` to
`CNC_xPRO_V5_XYYZ_PWM_NO` (the machine definition above)

As the first three changes are trivial for an end user they have been
left out.  Additionally, as per the [Grbl_Esp32 documentation][grbldocs]
it's highly recommended that users begin in "test drive" mode.  Thus,
that change has also not been included in this patch set.

Users should be able to follow the documentation above and compile with
predictable results.

Note: The author of this pull request has made no changes from the Spark
Concepts supplied sources with the exception of carriage returns which
were automatically removed by git (leaving line feeds).  The last line
of the file never contained a line feed.

[source-issue]: https://github.com/Spark-Concepts/xPro-V5/issues/8
[grbldocs]: https://github.com/bdring/Grbl_Esp32/wiki/Compiling-with-PlatformIO#customize-grbl_esp32srcmachineh